### PR TITLE
Update Spectrogram.py

### DIFF
--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -464,7 +464,7 @@ class Spectrogram(Dataset):
             audio_foldername, self.__spectro_foldername, "matrix"
         )
 
-        self.path_output_welch = self.path.joinpath(OSMOSE_PATH.welch)
+        self.path_output_welch = self.path.joinpath(OSMOSE_PATH.welch).joinpath(audio_foldername)
         self.path_output_LTAS = self.path.joinpath(OSMOSE_PATH.LTAS)
         self.path_output_EPD = self.path.joinpath(OSMOSE_PATH.EPD)
         self.path_output_SPLfiltered = self.path.joinpath(OSMOSE_PATH.SPLfiltered)


### PR DESCRIPTION
Modified path_output_welch to take into account audio foldername. Same behavior might need to be changed for LTAS/EPD and such.