### PR TITLE
[DRAFT] default log folder on initialize

### DIFF
--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -547,6 +547,11 @@ class Spectrogram(Dataset):
             "(Hz)",
         )
 
+    def prepare_paths(self, force_init: bool = False):
+        # create some internal paths
+        self.__build_path(force_init = force_init)
+
+
     def initialize(
         self,
         *,
@@ -598,8 +603,7 @@ class Spectrogram(Dataset):
                 mode=DPDEFAULT,
             )
 
-        # create some internal paths
-        self.__build_path(force_init=force_init)
+        self.prepare_paths(force_init = force_init)
 
         if not (
             self.path

--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -247,9 +247,11 @@ class Spectrogram(Dataset):
         self.__build_path(dry=True)
 
     @classmethod
-    def from_csv(cls, dataset_path: Path, metadata_csv_path: Path): # I don't want to use the dataset_path, but for now I have to
+    def from_csv(
+        cls, dataset_path: Path, metadata_csv_path: Path
+    ):  # I don't want to use the dataset_path, but for now I have to
         df = pd.read_csv(metadata_csv_path)
-        instance = cls(dataset_path = dataset_path)
+        instance = cls(dataset_path=dataset_path)
 
         for attribute in df:
             instance.__setattr__(attribute, df[attribute].values[0])
@@ -441,7 +443,7 @@ class Spectrogram(Dataset):
 
     @frequency_resolution.setter
     def frequency_resolution(self, value: float):
-        self._frequency_resolution = value # I don't know why this value is stored in the .csv, as it directly depends on dataset_sr and nfft
+        self._frequency_resolution = value  # I don't know why this value is stored in the .csv, as it directly depends on dataset_sr and nfft
 
     @property
     def time_resolution(self):
@@ -565,8 +567,7 @@ class Spectrogram(Dataset):
 
     def prepare_paths(self, force_init: bool = False):
         # create some internal paths
-        self.__build_path(force_init = force_init)
-
+        self.__build_path(force_init=force_init)
 
     def initialize(
         self,
@@ -619,7 +620,7 @@ class Spectrogram(Dataset):
                 mode=DPDEFAULT,
             )
 
-        self.prepare_paths(force_init = force_init)
+        self.prepare_paths(force_init=force_init)
 
         if not (
             self.path

--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -254,6 +254,8 @@ class Spectrogram(Dataset):
         for attribute in df:
             instance.__setattr__(attribute, df[attribute].values[0])
 
+        instance.prepare_paths()
+
         return instance
 
     @property

--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -246,6 +246,16 @@ class Spectrogram(Dataset):
 
         self.__build_path(dry=True)
 
+    @classmethod
+    def from_csv(cls, dataset_path: Path, metadata_csv_path: Path): # I don't want to use the dataset_path, but for now I have to
+        df = pd.read_csv(metadata_csv_path)
+        instance = cls(dataset_path = dataset_path)
+
+        for attribute in df:
+            instance.__setattr__(attribute, df[attribute].values[0])
+
+        return instance
+
     @property
     def dataset_sr(self):
         """int: The sampling frequency of the dataset."""
@@ -426,6 +436,10 @@ class Spectrogram(Dataset):
     def frequency_resolution(self) -> float:
         """Frequency resolution of the spectrogram, calculated by dividing the samplerate by nfft."""
         return self.dataset_sr / self.nfft
+
+    @frequency_resolution.setter
+    def frequency_resolution(self, value: float):
+        self._frequency_resolution = value # I don't know why this value is stored in the .csv, as it directly depends on dataset_sr and nfft
 
     @property
     def time_resolution(self):
@@ -911,7 +925,7 @@ class Spectrogram(Dataset):
         metadata.to_csv(new_meta_path, index=False)
         os.chmod(new_meta_path, mode=FPDEFAULT)
 
-    def save_spectro_metadata(self, adjust_bool: bool):
+    def save_spectro_metadata(self, adjust_bool: bool) -> Path:
         temporal_resolution, frequency_resolution, Nbwin = self.extract_spectro_params()
 
         data = {
@@ -964,6 +978,7 @@ class Spectrogram(Dataset):
 
         analysis_sheet.to_csv(meta_path, index=False)
         os.chmod(meta_path, mode=FPDEFAULT)
+        return meta_path
 
     def audio_file_list_csv(self) -> Path:
         list_audio = get_all_audio_files(self.path_input_audio_file)

--- a/src/OSmOSE/job.py
+++ b/src/OSmOSE/job.py
@@ -211,6 +211,7 @@ class Job_builder:
         *,
         script_path: str,
         script_args: str,
+        logdir: Path,
         jobname: str = None,
         preset: Literal["low", "medium", "high"] = None,
         job_scheduler: Literal["Torque", "Slurm"] = None,
@@ -223,7 +224,6 @@ class Job_builder:
         mem: str = None,
         outfile: str = None,
         errfile: str = None,
-        logdir: Path = None,
     ) -> str:
         """Build a job file corresponding to your job scheduler.
 
@@ -288,14 +288,7 @@ class Job_builder:
 
         pwd = Path(__file__).parent
 
-        if logdir is None:
-            logdir = pwd.joinpath("log_job")
-            jobdir = pwd.joinpath("ongoing_jobs")
-            logdir.mkdir(mode=DPDEFAULT, exist_ok=True)
-            jobdir.mkdir(mode=DPDEFAULT, exist_ok=True)
-        else:
-            logdir.mkdir(mode=DPDEFAULT, exist_ok=True)
-            jobdir = logdir
+        logdir.mkdir(mode=DPDEFAULT, exist_ok=True)
 
         job_file = ["#!/bin/bash"]
 
@@ -403,10 +396,10 @@ class Job_builder:
 
         #! FOOTER
         outfilename = (
-            f"{jobname}_{date_id}_{job_scheduler}_{len(os.listdir(jobdir))}.pbs"
+            f"{jobname}_{date_id}_{job_scheduler}_{len(os.listdir(logdir))}.pbs"
         )
 
-        job_file_path = jobdir.joinpath(outfilename)
+        job_file_path = logdir.joinpath(outfilename)
         job_file.append(f"\nrm {job_file_path}\n")
 
         #! BUILD DONE => WRITING


### PR DESCRIPTION
Right know, trying to create new spectrograms from a dataset that doesn't need reshaping (with bypassing the `initialize()` step) raises an exception because the folder creation is skipped.

This PR is linked to changes in the [datarmor toolkit](https://github.com/Project-OSmOSE/datarmor-toolkit/blob/main/src/utils_datarmor.py): right know, `build_job_files`'s `logdir` folder is optional, but should be mandatory.

Fixing that implies:

- making the `logdir` directory mandatory
- create the folder in which the spectrograms are to be stored even if the audio doesn't need to be reshaped


Changes also have to be done in the [datarmor toolkit](https://github.com/Project-OSmOSE/datarmor-toolkit/blob/main/src/utils_datarmor.py) to account for the case where a user wants to create spectrograms without reshaping the audio.