### PR TITLE
Hotfix/check permissions before chmod

### DIFF
--- a/src/OSmOSE/Dataset.py
+++ b/src/OSmOSE/Dataset.py
@@ -20,7 +20,7 @@ import pandas as pd
 import numpy as np
 from tqdm import tqdm
 from OSmOSE.utils.timestamp_utils import check_epoch
-from OSmOSE.utils.core_utils import check_n_files, set_umask
+from OSmOSE.utils.core_utils import check_n_files, set_umask, chmod_if_needed
 from OSmOSE.utils.path_utils import make_path
 from OSmOSE.timestamps import write_timestamp
 from OSmOSE.config import DPDEFAULT, FPDEFAULT, OSMOSE_PATH, TIMESTAMP_FORMAT_AUDIO_FILE

--- a/src/OSmOSE/Dataset.py
+++ b/src/OSmOSE/Dataset.py
@@ -347,7 +347,7 @@ class Dataset:
                         )
 
                 # Add the setgid bid to the folder's permissions, in order for subsequent created files to be created by the same user group.
-                os.chmod(self.path, DPDEFAULT)
+                chmod_if_needed(path=self.path, mode=DPDEFAULT)
 
         path_raw_audio = (
             original_folder
@@ -484,7 +484,7 @@ class Dataset:
 
         # write file_metadata.csv
         audio_metadata.to_csv(path_raw_audio.joinpath("file_metadata.csv"), index=False)
-        os.chmod(path_raw_audio.joinpath("file_metadata.csv"), mode=FPDEFAULT)
+        chmod_if_needed(path=path_raw_audio / "file_metadata.csv", mode=FPDEFAULT)
 
         # define anomaly tests of level 0 and 1
         test_level0_1 = (
@@ -583,7 +583,7 @@ class Dataset:
             df.sort_values(by=["timestamp"], inplace=True)
             df.to_csv(path_raw_audio.joinpath("timestamp.csv"), index=False)
 
-            os.chmod(path_raw_audio.joinpath("timestamp.csv"), mode=FPDEFAULT)
+            chmod_if_needed(path=path_raw_audio / "timestamp.csv", mode=FPDEFAULT)
 
             # change name of the original wav folder
             new_folder_name = path_raw_audio.parent.joinpath(
@@ -609,7 +609,7 @@ class Dataset:
                 pd.DataFrame(
                     [ff[0].replace("-", "_").replace(":", "_") for ff in xx]
                 ).to_csv(subset_path, index=False, header=None)
-                os.chmod(subset_path, mode=FPDEFAULT)
+                chmod_if_needed(path=subset_path, mode=FPDEFAULT)
 
             # write summary metadata.csv
             data = {
@@ -643,7 +643,7 @@ class Dataset:
                 mean(audio_metadata["duration"].values)
             )
             df.to_csv(path_raw_audio.joinpath("metadata.csv"), index=False)
-            os.chmod(path_raw_audio.joinpath("metadata.csv"), mode=FPDEFAULT)
+            chmod_if_needed(path=path_raw_audio / "metadata.csv", mode=FPDEFAULT)
 
             for path, _, files in os.walk(self.path.joinpath(OSMOSE_PATH.auxiliary)):
                 for f in files:
@@ -683,7 +683,7 @@ class Dataset:
             dataF["timestamp"] = list_cur_timestamp_formatted
 
             dataF.to_csv(cur_timestamp_not_formatted, index=False)
-            os.chmod(cur_timestamp_not_formatted, mode=FPDEFAULT)
+            chmod_if_needed(path=cur_timestamp_not_formatted, mode=FPDEFAULT)
 
             return None
 

--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -32,6 +32,7 @@ from OSmOSE.utils.core_utils import (
     safe_read,
     set_umask,
     get_timestamp_of_audio_file,
+    chmod_if_needed,
 )
 from OSmOSE.utils.audio_utils import get_all_audio_files
 from OSmOSE.config import OSMOSE_PATH, FPDEFAULT, DPDEFAULT
@@ -926,7 +927,7 @@ class Spectrogram(Dataset):
         if new_meta_path.exists():
             new_meta_path.unlink()
         metadata.to_csv(new_meta_path, index=False)
-        os.chmod(new_meta_path, mode=FPDEFAULT)
+        chmod_if_needed(path=new_meta_path, mode=FPDEFAULT)
 
     def save_spectro_metadata(self, adjust_bool: bool) -> Path:
         temporal_resolution, frequency_resolution, Nbwin = self.extract_spectro_params()
@@ -980,7 +981,7 @@ class Spectrogram(Dataset):
             meta_path.unlink()  # Always overwrite this file
 
         analysis_sheet.to_csv(meta_path, index=False)
-        os.chmod(meta_path, mode=FPDEFAULT)
+        chmod_if_needed(path=meta_path, mode=FPDEFAULT)
         return meta_path
 
     def audio_file_list_csv(self) -> Path:
@@ -994,7 +995,7 @@ class Spectrogram(Dataset):
             with open(csv_path, "w") as f:
                 f.write("\n".join([str(audio) for audio in list_audio]))
 
-            os.chmod(csv_path, mode=FPDEFAULT)
+            chmod_if_needed(path=csv_path, mode=FPDEFAULT)
 
             return csv_path
 
@@ -1047,7 +1048,9 @@ class Spectrogram(Dataset):
         if not filename.exists():
             pd.DataFrame.from_records([new_params]).to_csv(filename, index=False)
 
-            os.chmod(filename, mode=DPDEFAULT)
+            chmod_if_needed(
+                path=filename, mode=FPDEFAULT
+            )  # This was DPDEFAULT: was it intentional?
             return True
 
         orig_params = pd.read_csv(filename, header=0)
@@ -1062,7 +1065,9 @@ class Spectrogram(Dataset):
             filename.unlink()
             pd.DataFrame.from_records([new_params]).to_csv(filename, index=False)
 
-            os.chmod(filename, mode=DPDEFAULT)
+            chmod_if_needed(
+                path=filename, mode=FPDEFAULT
+            )  # This was DPDEFAULT: was it intentional?
             return True
         return False
 
@@ -1333,7 +1338,7 @@ class Spectrogram(Dataset):
                     Time=list_timestamps,
                 )
 
-                os.chmod(output_matrix, mode=FPDEFAULT)
+                chmod_if_needed(path=output_matrix, mode=FPDEFAULT)
 
         # loop over the zoom levels from the second lowest to the highest one
         for zoom_level in range(self.zoom_level + 1)[::-1]:
@@ -1389,7 +1394,7 @@ class Spectrogram(Dataset):
                         Time=current_timestamp,
                     )
 
-                    os.chmod(output_matrix, mode=FPDEFAULT)
+                    chmod_if_needed(path=output_matrix, mode=FPDEFAULT)
 
     def gen_spectro(
         self, *, data: np.ndarray, sample_rate: int, output_file: Path
@@ -1476,7 +1481,7 @@ class Spectrogram(Dataset):
                     Time=Time,
                 )
 
-                os.chmod(output_matrix, mode=FPDEFAULT)
+                chmod_if_needed(path=output_matrix, mode=FPDEFAULT)
 
         return Sxx, Freq
 
@@ -1552,7 +1557,7 @@ class Spectrogram(Dataset):
         plt.savefig(output_file, bbox_inches="tight", pad_inches=0)
         plt.close()
 
-        os.chmod(output_file, mode=FPDEFAULT)
+        chmod_if_needed(path=output_file, mode=FPDEFAULT)
 
         if adjust:
             display(Image(output_file))

--- a/src/OSmOSE/cluster/audio_reshaper.py
+++ b/src/OSmOSE/cluster/audio_reshaper.py
@@ -13,6 +13,7 @@ from OSmOSE.utils import (
     get_all_audio_files,
     set_umask,
     make_path,
+    chmod_if_needed,
 )
 
 
@@ -319,7 +320,7 @@ def reshape(
             audio_data,
             new_sr,
         )
-        os.chmod(out_filename, mode=FPDEFAULT)
+        chmod_if_needed(path=out_filename, mode=FPDEFAULT)
         msg_log += f"Saved file from {segment_datetime_begin} to {segment_datetime_end} as {out_filename}\n"
 
     # writing infos to timestamp_*.csv
@@ -330,7 +331,7 @@ def reshape(
         index=False,
         na_rep="NaN",
     )
-    os.chmod((output_dir_path / f"timestamp_{batch}.csv"), mode=FPDEFAULT)
+    chmod_if_needed(path=output_dir_path / f"timestamp_{batch}.csv", mode=FPDEFAULT)
     msg_log += f"Saved timestamp csv file as timestamp_{batch}.csv\n"
     msg_log += f"Reshape for batch_{batch} completed\n"
 

--- a/src/OSmOSE/job.py
+++ b/src/OSmOSE/job.py
@@ -12,7 +12,7 @@ from warnings import warn
 from pathlib import Path
 from datetime import datetime, timedelta
 from importlib import resources
-from OSmOSE.utils.core_utils import read_config, set_umask
+from OSmOSE.utils.core_utils import read_config, set_umask, chmod_if_needed
 from OSmOSE.config import *
 
 JOB_CONFIG_TEMPLATE = namedtuple(
@@ -503,9 +503,9 @@ class Job_builder:
         for job_info in self.finished_jobs:
             try:
                 if job_info["outfile"].exists():
-                    os.chmod(job_info["outfile"], FPDEFAULT)
+                    chmod_if_needed(path=job_info["outfile"], mode=FPDEFAULT)
                 if job_info["errfile"].exists():
-                    os.chmod(job_info["errfile"], FPDEFAULT)
+                    chmod_if_needed(path=job_info["errfile"], mode=FPDEFAULT)
             except KeyError:
                 print(f"No outfile or errfile associated with job {job_info['path']}.")
 

--- a/src/OSmOSE/timestamps.py
+++ b/src/OSmOSE/timestamps.py
@@ -149,7 +149,7 @@ def write_timestamp(
     df = pd.DataFrame({"filename": filename_raw_audio, "timestamp": timestamp})
     df.sort_values(by=["timestamp"], inplace=True)
     df.to_csv(Path(audio_path, "timestamp.csv"), index=False, na_rep="NaN")
-    os.chmod(Path(audio_path, "timestamp.csv"), mode=FPDEFAULT)
+    chmod_if_needed(path=Path(audio_path) / "timestamp.csv", mode=FPDEFAULT)
 
 
 if __name__ == "__main__":

--- a/src/OSmOSE/timestamps.py
+++ b/src/OSmOSE/timestamps.py
@@ -6,7 +6,7 @@ import pandas as pd
 from pathlib import Path
 
 from OSmOSE.config import *
-from OSmOSE.utils.core_utils import get_files
+from OSmOSE.utils.core_utils import get_files, chmod_if_needed
 
 __converter = {
     "%Y": r"[12][0-9]{3}",

--- a/src/OSmOSE/utils/core_utils.py
+++ b/src/OSmOSE/utils/core_utils.py
@@ -745,3 +745,12 @@ def add_entry_for_APLOSE(path: str, file: str, info: pd.DataFrame):
             by=["path", "dataset"], ascending=True
         )
         meta.to_csv(dataset_csv, index=False)
+
+def chmod_if_needed(path: Path, mode: int):
+    if all(os.access(path, p) for p in (os.R_OK, os.W_OK)):
+        return
+
+    try:
+        os.chmod(path, mode)
+    except PermissionError:
+        raise PermissionError(f"You do not have the permission to write to {path}, nor to change its permissions.")

--- a/src/OSmOSE/utils/core_utils.py
+++ b/src/OSmOSE/utils/core_utils.py
@@ -746,6 +746,7 @@ def add_entry_for_APLOSE(path: str, file: str, info: pd.DataFrame):
         )
         meta.to_csv(dataset_csv, index=False)
 
+
 def chmod_if_needed(path: Path, mode: int):
     if all(os.access(path, p) for p in (os.R_OK, os.W_OK)):
         return
@@ -753,4 +754,6 @@ def chmod_if_needed(path: Path, mode: int):
     try:
         os.chmod(path, mode)
     except PermissionError:
-        raise PermissionError(f"You do not have the permission to write to {path}, nor to change its permissions.")
+        raise PermissionError(
+            f"You do not have the permission to write to {path}, nor to change its permissions."
+        )


### PR DESCRIPTION
This PR should fix a bug where OSEkit unnecessarily tries to change folders/files for which it already has write/read accesses but for which it doesn't have the permission to change the permissions.

Basically, the `os.chmod` function should now only be called if the user **doesn't have** the read and write permissions to the file or folder.

@cazaudo: In the `Spectrogram` class, 2 files permissions were changed to the `DPDEFAULT` mode:
Line `1050`
```py
if not filename.exists():
  pd.DataFrame.from_records([new_params]).to_csv(filename, index=False)  
  os.chmod(filename, mode=DPDEFAULT)
  return True
```

Line `1065`
```py
filename.unlink()
pd.DataFrame.from_records([new_params]).to_csv(filename, index=False)
os.chmod(filename, mode=DPDEFAULT)
return True
```

I changed the modes to `FPDEFAULT`, and added a comment to keep track of that: 
```py
if not filename.exists():
  pd.DataFrame.from_records([new_params]).to_csv(filename, index=False)
  chmod_if_needed(
      path=filename, mode=FPDEFAULT
  )  # This was DPDEFAULT: was it intentional?
  return True
```
I'll remove the comment if you validate that the mode should be `FPDEFAULT`, or change back to `DPDEFAULT`