### PR TITLE
Ruff linting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,6 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-from pathlib import Path
 import os
 import sys
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+
 import sphinx_rtd_theme
 
 sys.path.insert(0, os.path.abspath("../src/"))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+import sphinx_rtd_theme
 
 sys.path.insert(0, os.path.abspath("../src/"))
 
@@ -60,8 +61,6 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 #
 
 # html_theme = "alabaster"
-import sphinx_rtd_theme
-
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3317,6 +3317,33 @@ files = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.7.1"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.7.1-py3-none-linux_armv6l.whl", hash = "sha256:cb1bc5ed9403daa7da05475d615739cc0212e861b7306f314379d958592aaa89"},
+    {file = "ruff-0.7.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:27c1c52a8d199a257ff1e5582d078eab7145129aa02721815ca8fa4f9612dc35"},
+    {file = "ruff-0.7.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:588a34e1ef2ea55b4ddfec26bbe76bc866e92523d8c6cdec5e8aceefeff02d99"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94fc32f9cdf72dc75c451e5f072758b118ab8100727168a3df58502b43a599ca"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:985818742b833bffa543a84d1cc11b5e6871de1b4e0ac3060a59a2bae3969250"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:32f1e8a192e261366c702c5fb2ece9f68d26625f198a25c408861c16dc2dea9c"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:699085bf05819588551b11751eff33e9ca58b1b86a6843e1b082a7de40da1565"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:344cc2b0814047dc8c3a8ff2cd1f3d808bb23c6658db830d25147339d9bf9ea7"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4316bbf69d5a859cc937890c7ac7a6551252b6a01b1d2c97e8fc96e45a7c8b4a"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79d3af9dca4c56043e738a4d6dd1e9444b6d6c10598ac52d146e331eb155a8ad"},
+    {file = "ruff-0.7.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c5c121b46abde94a505175524e51891f829414e093cd8326d6e741ecfc0a9112"},
+    {file = "ruff-0.7.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8422104078324ea250886954e48f1373a8fe7de59283d747c3a7eca050b4e378"},
+    {file = "ruff-0.7.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:56aad830af8a9db644e80098fe4984a948e2b6fc2e73891538f43bbe478461b8"},
+    {file = "ruff-0.7.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:658304f02f68d3a83c998ad8bf91f9b4f53e93e5412b8f2388359d55869727fd"},
+    {file = "ruff-0.7.1-py3-none-win32.whl", hash = "sha256:b517a2011333eb7ce2d402652ecaa0ac1a30c114fbbd55c6b8ee466a7f600ee9"},
+    {file = "ruff-0.7.1-py3-none-win_amd64.whl", hash = "sha256:f38c41fcde1728736b4eb2b18850f6d1e3eedd9678c914dede554a70d5241307"},
+    {file = "ruff-0.7.1-py3-none-win_arm64.whl", hash = "sha256:19aa200ec824c0f36d0c9114c8ec0087082021732979a359d6f3c390a6ff2a37"},
+    {file = "ruff-0.7.1.tar.gz", hash = "sha256:9d8a41d4aa2dad1575adb98a82870cf5db5f76b2938cf2206c22c940034a36f4"},
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.5.2"
 description = "A set of python modules for machine learning and data mining"
@@ -4048,4 +4075,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a580f65d0515e2c4514e9a612851698c376db418689a668dee451562c956c8b1"
+content-hash = "79f691e6cb7701aefea67c6c9f78e8c80f72a91a1f55f7f1e7264e2f9e4afba5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,11 @@ markers = [
     "reg: Mark test as regression test. Run only these with '-m ref'."
 ]
 
+[tool.ruff]
+select = ["ALL"]
+
+[tool.ruff.lint.extend-per-file-ignores]
+"tests/**/*.py" = [
+    # at least this three should be fine in tests:
+    "S101", # asserts allowed in tests...
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ pytest = "^7.2.1"
 black = "^24.4.2"
 pytest-cov = "^4.0.0"
 jupyter = "^1.0.0"
+ruff = "^0.7.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/OSmOSE/Auxiliary.py
+++ b/src/OSmOSE/Auxiliary.py
@@ -7,8 +7,8 @@ import netCDF4 as nc
 from typing import Union, Tuple, List
 from datetime import datetime, timedelta
 from OSmOSE.utils.timestamp_utils import check_epoch
-from OSmOSE.config import *
 from OSmOSE.Spectrogram import Spectrogram
+from OSmOSE.config import OSMOSE_PATH
 from scipy import interpolate
 
 
@@ -18,7 +18,7 @@ class Auxiliary(Spectrogram):
     The acoustic data is first fetched using the dataset path, the data's samplerate and the analysis parameters.
     If no analysis parameters are provided then data will be joined to corresponding raw audio files.
     """
-
+    
     # CHECK THAT ALL TIMEZONES ARE THE SAME PLEASE (UTC 00)
 
     def __init__(
@@ -153,7 +153,7 @@ class Auxiliary(Spectrogram):
                 self.depth.epoch, self.depth.depth, bounds_error=False
             )(self.df.epoch)
 
-        elif type(self.depth) == int:
+        elif type(self.depth) is int:
             self.df["depth"] = self.depth
 
     def join_gps(self):
@@ -252,7 +252,7 @@ def make_cds_file(key, udi, path):
     os.system(cmd1)
     os.system(cmd2)
 
-    if path == None:
+    if path is None:
         try:
             os.mkdir("api")
         except FileExistsError:
@@ -271,7 +271,7 @@ def make_cds_file(key, udi, path):
 
 def return_cdsapi(filename, key, variables, years, months, days, hours, area):
     print("You have selected : \n")
-    sel = [print(variables) for data in variables]
+    [print(variables) for data in variables]
     print("\nfor the following times")
     print(f"Years : {years} \n Months : {months} \n Days : {days} \n Hours : {hours}")
 

--- a/src/OSmOSE/Auxiliary.py
+++ b/src/OSmOSE/Auxiliary.py
@@ -68,7 +68,8 @@ class Auxiliary(Spectrogram):
         # Load reference data that will be used to join all other data
         self.df = check_epoch(pd.read_csv(self.audio_path.joinpath("timestamp.csv")))
         self.metadata = pd.read_csv(
-            self._get_original_after_build().joinpath("metadata.csv"), header=0,
+            self._get_original_after_build().joinpath("metadata.csv"),
+            header=0,
         )
         self._depth, self._gps_coordinates = depth, gps_coordinates
         match depth:
@@ -149,7 +150,9 @@ class Auxiliary(Spectrogram):
             ), "Make sure the depth file has both an 'epoch' and 'depth' column."
             # Join data using a 1D interpolation
             self.df["depth"] = interpolate.interp1d(
-                self.depth.epoch, self.depth.depth, bounds_error=False,
+                self.depth.epoch,
+                self.depth.depth,
+                bounds_error=False,
             )(self.df.epoch)
 
         elif type(self.depth) is int:
@@ -167,10 +170,14 @@ class Auxiliary(Spectrogram):
             ), "Make sure the depth file has both an 'epoch' and 'lat'/'lon' columns."
             # Join data using a 1D interpolation
             self.df["lat"] = interpolate.interp1d(
-                self.gps_coordinates.epoch, self.gps_coordinates.lat, bounds_error=False,
+                self.gps_coordinates.epoch,
+                self.gps_coordinates.lat,
+                bounds_error=False,
             )(self.df.epoch)
             self.df["lon"] = interpolate.interp1d(
-                self.gps_coordinates.epoch, self.gps_coordinates.lon, bounds_error=False,
+                self.gps_coordinates.epoch,
+                self.gps_coordinates.lon,
+                bounds_error=False,
             )(self.df.epoch)
 
         elif type(self.gps_coordinates) in [list, tuple]:
@@ -178,7 +185,9 @@ class Auxiliary(Spectrogram):
             self.df["lon"] = self.gps_coordinates[1]
 
     def join_other(
-        self, csv_path: str = None, variable_name: Union[str, List, Tuple] = None,
+        self,
+        csv_path: str = None,
+        variable_name: Union[str, List, Tuple] = None,
     ):
         """Method to join data using solely temporal interpolation.
 
@@ -197,7 +206,9 @@ class Auxiliary(Spectrogram):
         for key in self.other.keys():
             _csv = check_epoch(pd.read_csv(self.other[key]))
             self.df[key] = interpolate.interp1d(
-                _csv.epoch, _csv[key], bounds_error=False,
+                _csv.epoch,
+                _csv[key],
+                bounds_error=False,
             )(self.df.epoch)
 
     def interpolation_era(self):

--- a/src/OSmOSE/Auxiliary.py
+++ b/src/OSmOSE/Auxiliary.py
@@ -1,13 +1,11 @@
 import cdsapi
-import numpy as np
 import pandas as pd
 import os
-import calendar
 from glob import glob
 from tqdm import tqdm
 import netCDF4 as nc
 from typing import Union, Tuple, List
-from datetime import datetime, date, timedelta
+from datetime import datetime, timedelta
 from OSmOSE.utils.timestamp_utils import check_epoch
 from OSmOSE.config import *
 from OSmOSE.Spectrogram import Spectrogram

--- a/src/OSmOSE/Dataset.py
+++ b/src/OSmOSE/Dataset.py
@@ -79,7 +79,8 @@ class Dataset:
 
         """
         assert isinstance(dataset_path, Path) or isinstance(
-            dataset_path, str,
+            dataset_path,
+            str,
         ), f"Expected value to be a Path or a string, but got {type(dataset_path).__name__}"
         # assert gps_coordinates
 
@@ -319,7 +320,8 @@ class Dataset:
 
         """
         metadata_path = next(
-            self.path.joinpath(OSMOSE_PATH.raw_audio).rglob("metadata.csv"), False,
+            self.path.joinpath(OSMOSE_PATH.raw_audio).rglob("metadata.csv"),
+            False,
         )
         if (
             metadata_path
@@ -371,7 +373,8 @@ class Dataset:
 
         if not user_timestamp:
             self._write_timestamp_csv_from_audio_files(
-                audio_path=path_raw_audio, date_template=date_template,
+                audio_path=path_raw_audio,
+                date_template=date_template,
             )
 
         resume_test_anomalies = path_raw_audio.joinpath("resume_test_anomalies.txt")
@@ -415,7 +418,9 @@ class Dataset:
             audio_file = audio_file_list[ind_dt]
 
             cur_timestamp, _ = self._format_timestamp(
-                timestamp_csv[ind_dt], date_template, already_printed_1,
+                timestamp_csv[ind_dt],
+                date_template,
+                already_printed_1,
             )
             # define final audio filename, especially we remove the sign '-' in filenames (because of our qsub_resample.sh)
             if ("-" in audio_file.name) or (":" in audio_file.name):
@@ -484,7 +489,8 @@ class Dataset:
             )
             new_data = new_data.dropna(axis=1, how="all")
             audio_metadata = pd.concat(
-                [audio_metadata if not audio_metadata.empty else None, new_data], axis=0,
+                [audio_metadata if not audio_metadata.empty else None, new_data],
+                axis=0,
             )
 
         audio_metadata["duration_inter_file"] = audio_metadata["duration"].diff()
@@ -630,10 +636,12 @@ class Dataset:
                     mean(audio_metadata["duration"].values),
                 ),
                 "audio_file_origin_volume": round(
-                    mean(audio_metadata["size"].values), 1,
+                    mean(audio_metadata["size"].values),
+                    1,
                 ),
                 "dataset_origin_volume": max(
-                    1, round(sum(audio_metadata["size"].values) / 1000),
+                    1,
+                    round(sum(audio_metadata["size"].values) / 1000),
                 ),  # cannot be inferior to 1 GB
                 "dataset_origin_duration": round(
                     sum(audio_metadata["duration"].values),
@@ -663,17 +671,22 @@ class Dataset:
             print("\n DONE ! your dataset is on OSmOSE platform !")
 
     def _write_timestamp_csv_from_audio_files(
-        self, audio_path: Path, date_template: str,
+        self,
+        audio_path: Path,
+        date_template: str,
     ):
         supported_audio_files = [file.name for file in get_all_audio_files(audio_path)]
         filenames_with_timestamps = associate_timestamps(
-            audio_files=supported_audio_files, datetime_template=date_template,
+            audio_files=supported_audio_files,
+            datetime_template=date_template,
         )
         filenames_with_timestamps["timestamp"] = filenames_with_timestamps[
             "timestamp"
         ].apply(lambda t: strftime_osmose_format(t))
         filenames_with_timestamps.to_csv(
-            audio_path / "timestamp.csv", index=False, na_rep="NaN",
+            audio_path / "timestamp.csv",
+            index=False,
+            na_rep="NaN",
         )
         os.chmod(audio_path / "timestamp.csv", mode=FPDEFAULT)
 
@@ -691,7 +704,9 @@ class Dataset:
             dataF = pd.read_csv(cur_timestamp_not_formatted)
             for val_timestamp_not_formatted in dataF["timestamp"].values:
                 cur_timestamp_formatted, format_OK = self._format_timestamp(
-                    val_timestamp_not_formatted, date_template, True,
+                    val_timestamp_not_formatted,
+                    date_template,
+                    True,
                 )
                 if format_OK:
                     print("-> Format OK \n")
@@ -716,7 +731,8 @@ class Dataset:
 
         try:
             datetime.strptime(
-                cur_timestamp_not_formatted, TIMESTAMP_FORMAT_AUDIO_FILE,
+                cur_timestamp_not_formatted,
+                TIMESTAMP_FORMAT_AUDIO_FILE,
             )
             cur_timestamp_formatted = cur_timestamp_not_formatted
             format_OK = True
@@ -730,10 +746,12 @@ class Dataset:
             if not date_template:
                 raise FileNotFoundError("You have to define a date_template please.")
             date_obj = datetime.strptime(
-                cur_timestamp_not_formatted + self.timezone, date_template + "%z",
+                cur_timestamp_not_formatted + self.timezone,
+                date_template + "%z",
             )
             cur_timestamp_formatted = datetime.strftime(
-                date_obj, TIMESTAMP_FORMAT_AUDIO_FILE,
+                date_obj,
+                TIMESTAMP_FORMAT_AUDIO_FILE,
             )
 
         return cur_timestamp_formatted, format_OK
@@ -790,7 +808,8 @@ class Dataset:
                     else:
                         for key_dico in self.dico_aux_substring:
                             if re.search(
-                                "|".join(self.dico_aux_substring[key_dico]), f,
+                                "|".join(self.dico_aux_substring[key_dico]),
+                                f,
                             ):
                                 Path(path, f).rename(
                                     self.path / OSMOSE_PATH.auxiliary / key_dico / f,
@@ -845,7 +864,8 @@ class Dataset:
         origin_sr = int(metadata["origin_sr"][0])
 
         self.__original_folder = self.path.joinpath(
-            OSMOSE_PATH.raw_audio, f"{audio_file_origin_duration}_{origin_sr}",
+            OSMOSE_PATH.raw_audio,
+            f"{audio_file_origin_duration}_{origin_sr}",
         )
 
         return self.original_folder

--- a/src/OSmOSE/Dataset.py
+++ b/src/OSmOSE/Dataset.py
@@ -224,7 +224,7 @@ class Dataset:
                 self.__depth = new_depth
             case _:
                 raise TypeError(
-                    f"Variable depth must be either an int value for fixed hydrophone or a csv filename for moving hydrophone"
+                    "Variable depth must be either an int value for fixed hydrophone or a csv filename for moving hydrophone"
                 )
 
     @property
@@ -328,9 +328,9 @@ class Dataset:
             sys.exit()
 
         if self.gps_coordinates is None:
-            raise ValueError(f"GPS coordinates must be defined !")
+            raise ValueError("GPS coordinates must be defined !")
         if self.depth is None:
-            raise ValueError(f"Depth must be defined !")
+            raise ValueError("Depth must be defined !")
 
         self.dico_aux_substring = dico_aux_substring
 
@@ -420,7 +420,7 @@ class Dataset:
                 )
                 if ind_dt == 0:
                     print(
-                        f"\n We do not accept the sign '-' in our filenames, we transformed them into '_'. In case you have to rebuild your dataset be careful to change your timestamp template accordingly.. \n"
+                        "\n We do not accept the sign '-' in our filenames, we transformed them into '_'. In case you have to rebuild your dataset be careful to change your timestamp template accordingly.. \n"
                     )
             else:
                 cur_filename = audio_file.name
@@ -689,7 +689,7 @@ class Dataset:
                     val_timestamp_not_formatted, date_template, True
                 )
                 if format_OK:
-                    print(f"-> Format OK \n")
+                    print("-> Format OK \n")
                     return None
                 else:
                     list_cur_timestamp_formatted.append(cur_timestamp_formatted)
@@ -717,14 +717,14 @@ class Dataset:
             cur_timestamp_formatted = cur_timestamp_not_formatted
             format_OK = True
 
-        except Exception as e:
+        except Exception:
             if not already_printed_1:
                 already_printed_1 = True
                 print(
                     f"Timestamp format {cur_timestamp_not_formatted} does not fit our template {TIMESTAMP_FORMAT_AUDIO_FILE} let's reformat it"
                 )
             if not date_template:
-                raise FileNotFoundError(f"You have to define a date_template please.")
+                raise FileNotFoundError("You have to define a date_template please.")
             else:
                 date_obj = datetime.strptime(
                     cur_timestamp_not_formatted + self.timezone, date_template + "%z"

--- a/src/OSmOSE/Dataset.py
+++ b/src/OSmOSE/Dataset.py
@@ -1,12 +1,13 @@
 import os
-from pathlib import Path
-from typing import Union, Tuple, List
-from datetime import datetime
-from statistics import fmean as mean
-import shutil
-from os import PathLike
-import sys
 import re
+import shutil
+import sys
+from datetime import datetime
+from os import PathLike
+from pathlib import Path
+from statistics import fmean as mean
+from typing import List, Tuple, Union
+
 import soundfile as sf
 
 try:
@@ -16,18 +17,19 @@ try:
 except ModuleNotFoundError:
     skip_perms = True
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 from tqdm import tqdm
+
+from OSmOSE.config import DPDEFAULT, FPDEFAULT, OSMOSE_PATH, TIMESTAMP_FORMAT_AUDIO_FILE
 from OSmOSE.utils.audio_utils import get_all_audio_files
+from OSmOSE.utils.core_utils import check_n_files, chmod_if_needed, set_umask
+from OSmOSE.utils.path_utils import make_path
 from OSmOSE.utils.timestamp_utils import (
-    check_epoch,
     associate_timestamps,
+    check_epoch,
     strftime_osmose_format,
 )
-from OSmOSE.utils.core_utils import check_n_files, set_umask, chmod_if_needed
-from OSmOSE.utils.path_utils import make_path
-from OSmOSE.config import DPDEFAULT, FPDEFAULT, OSMOSE_PATH, TIMESTAMP_FORMAT_AUDIO_FILE
 
 
 class Dataset:
@@ -74,9 +76,10 @@ class Dataset:
         >>> from pathlib import Path
         >>> from OSmOSE import Dataset
         >>> dataset = Dataset(Path("home","user","my_dataset"), coordinates = [49.2, -5], owner_group = "gosmose")
+
         """
         assert isinstance(dataset_path, Path) or isinstance(
-            dataset_path, str
+            dataset_path, str,
         ), f"Expected value to be a Path or a string, but got {type(dataset_path).__name__}"
         # assert gps_coordinates
 
@@ -98,7 +101,7 @@ class Dataset:
 
         if skip_perms:
             print(
-                "It seems you are on a non-Unix operating system (probably Windows). The build() method will not work as intended and permission might be incorrectly set."
+                "It seems you are on a non-Unix operating system (probably Windows). The build() method will not work as intended and permission might be incorrectly set.",
             )
 
         pd.set_option("display.float_format", lambda x: "%.0f" % x)
@@ -142,6 +145,7 @@ class Dataset:
         Returns
         -------
         The GPS coordinates as a tuple.
+
         """
         return self.__gps_coordinates
 
@@ -170,7 +174,7 @@ class Dataset:
                     ]"""
                 else:
                     raise FileNotFoundError(
-                        f"The {new_coordinates} has been found no where within {self.path}"
+                        f"The {new_coordinates} has been found no where within {self.path}",
                     )
 
             case tuple():
@@ -179,7 +183,7 @@ class Dataset:
                 self.__gps_coordinates = new_coordinates
             case _:
                 raise TypeError(
-                    f"GPS coordinates must be either a list of coordinates or the name of csv containing the coordinates, but {type(new_coordinates)} found."
+                    f"GPS coordinates must be either a list of coordinates or the name of csv containing the coordinates, but {type(new_coordinates)} found.",
                 )
 
     @property
@@ -196,6 +200,7 @@ class Dataset:
         Returns
         -------
         The depth as an int.
+
         """
         return self.__depth
 
@@ -217,14 +222,14 @@ class Dataset:
                     self.__depth = int(np.mean(csvFileArray["depth"]))"""
                 else:
                     raise FileNotFoundError(
-                        f"The {new_depth} has been found no where within {self.path}"
+                        f"The {new_depth} has been found no where within {self.path}",
                     )
 
             case int():
                 self.__depth = new_depth
             case _:
                 raise TypeError(
-                    "Variable depth must be either an int value for fixed hydrophone or a csv filename for moving hydrophone"
+                    "Variable depth must be either an int value for fixed hydrophone or a csv filename for moving hydrophone",
                 )
 
     @property
@@ -232,7 +237,7 @@ class Dataset:
         """str: The Unix group able to interact with the dataset."""
         if self.__group is None:
             print(
-                "The OSmOSE group name is not defined. Please specify the group name before trying to build the dataset."
+                "The OSmOSE group name is not defined. Please specify the group name before trying to build the dataset.",
             )
         return self.__group
 
@@ -247,7 +252,7 @@ class Dataset:
                 grp.getgrnam(value).gr_gid
             except KeyError as e:
                 raise KeyError(
-                    f"The group {value} does not exist on the system. Full error trace: {e}"
+                    f"The group {value} does not exist on the system. Full error trace: {e}",
                 )
 
         self.__group = value
@@ -267,8 +272,7 @@ class Dataset:
             "environment": ["insitu"],
         },
     ) -> Path:
-        """
-        Set up the architecture of the dataset.
+        """Set up the architecture of the dataset.
 
         The following operations will be performed on the dataset. None of them are destructive:
             - open and read the header of audio files located in `raw/audio/original/`.
@@ -312,9 +316,10 @@ class Dataset:
             >>> dataset.build()
 
             DONE ! your dataset is on OSmOSE platform !
+
         """
         metadata_path = next(
-            self.path.joinpath(OSMOSE_PATH.raw_audio).rglob("metadata.csv"), False
+            self.path.joinpath(OSMOSE_PATH.raw_audio).rglob("metadata.csv"), False,
         )
         if (
             metadata_path
@@ -323,7 +328,7 @@ class Dataset:
             and not force_upload
         ):
             print(
-                "This dataset has already been built. To run the build() method on an already built dataset, you have to use the force_upload parameter."
+                "This dataset has already been built. To run the build() method on an already built dataset, you have to use the force_upload parameter.",
             )
             sys.exit()
 
@@ -347,7 +352,7 @@ class Dataset:
                         os.chown(self.path, -1, gid)
                     except PermissionError:
                         print(
-                            f"You have not the permission to change the owner of the {self.path} folder. This might be because you are trying to rebuild an existing dataset. The group owner has not been changed."
+                            f"You have not the permission to change the owner of the {self.path} folder. This might be because you are trying to rebuild an existing dataset. The group owner has not been changed.",
                         )
 
                 # Add the setgid bid to the folder's permissions, in order for subsequent created files to be created by the same user group.
@@ -366,7 +371,7 @@ class Dataset:
 
         if not user_timestamp:
             self._write_timestamp_csv_from_audio_files(
-                audio_path=path_raw_audio, date_template=date_template
+                audio_path=path_raw_audio, date_template=date_template,
             )
 
         resume_test_anomalies = path_raw_audio.joinpath("resume_test_anomalies.txt")
@@ -387,7 +392,7 @@ class Dataset:
                 "sampwidth",
                 "channel_count",
                 "status_read_header",
-            ]
+            ],
         )
         audio_metadata["status_read_header"] = audio_metadata[
             "status_read_header"
@@ -410,17 +415,17 @@ class Dataset:
             audio_file = audio_file_list[ind_dt]
 
             cur_timestamp, _ = self._format_timestamp(
-                timestamp_csv[ind_dt], date_template, already_printed_1
+                timestamp_csv[ind_dt], date_template, already_printed_1,
             )
             # define final audio filename, especially we remove the sign '-' in filenames (because of our qsub_resample.sh)
             if ("-" in audio_file.name) or (":" in audio_file.name):
                 cur_filename = audio_file.name.replace("-", "_").replace(":", "_")
                 path_raw_audio.joinpath(audio_file.name).rename(
-                    path_raw_audio.joinpath(cur_filename)
+                    path_raw_audio.joinpath(cur_filename),
                 )
                 if ind_dt == 0:
                     print(
-                        "\n We do not accept the sign '-' in our filenames, we transformed them into '_'. In case you have to rebuild your dataset be careful to change your timestamp template accordingly.. \n"
+                        "\n We do not accept the sign '-' in our filenames, we transformed them into '_'. In case you have to rebuild your dataset be careful to change your timestamp template accordingly.. \n",
                     )
             else:
                 cur_filename = audio_file.name
@@ -479,7 +484,7 @@ class Dataset:
             )
             new_data = new_data.dropna(axis=1, how="all")
             audio_metadata = pd.concat(
-                [audio_metadata if not audio_metadata.empty else None, new_data], axis=0
+                [audio_metadata if not audio_metadata.empty else None, new_data], axis=0,
             )
 
         audio_metadata["duration_inter_file"] = audio_metadata["duration"].diff()
@@ -494,22 +499,22 @@ class Dataset:
                 np.unique(
                     audio_metadata["origin_sr"].values[
                         ~pd.isna(audio_metadata["origin_sr"].values)
-                    ]
-                )
+                    ],
+                ),
             )
             == 1
         )
         test_level0_2 = number_bad_files == 0
         test_level0_3 = sum(audio_metadata["status_read_header"].values) == len(
-            timestamp_csv
+            timestamp_csv,
         )
         test_level1_1 = (
             len(
                 np.unique(
                     audio_metadata["duration"].values[
                         ~pd.isna(audio_metadata["duration"].values)
-                    ]
-                )
+                    ],
+                ),
             )
             == 1
         )
@@ -542,14 +547,14 @@ class Dataset:
             len(list_tests_level0) - sum(list_tests_level0) > 0
         ):  # if presence of anomalies of level 0
             print(
-                f"\n\n Your dataset failed {len(list_tests_level0)-sum(list_tests_level0)} anomaly test of level 0 (over {len(list_tests_level0)}); see details below. \n Anomalies of level 0 block dataset uploading as long as they are present. Please correct your anomalies first, and try uploading it again after. \n You can inspect your metadata saved here {path_raw_audio.joinpath('file_metadata.csv')} using the notebook /home/datawork-osmose/osmose-datarmor/notebooks/metadata_analyzer.ipynb."
+                f"\n\n Your dataset failed {len(list_tests_level0)-sum(list_tests_level0)} anomaly test of level 0 (over {len(list_tests_level0)}); see details below. \n Anomalies of level 0 block dataset uploading as long as they are present. Please correct your anomalies first, and try uploading it again after. \n You can inspect your metadata saved here {path_raw_audio.joinpath('file_metadata.csv')} using the notebook /home/datawork-osmose/osmose-datarmor/notebooks/metadata_analyzer.ipynb.",
             )
 
             if (
                 len(list_tests_level1) - sum(list_tests_level1) > 0
             ):  # if also presence of anomalies of level 1
                 print(
-                    f"\n Your dataset also failed {len(list_tests_level1)-sum(list_tests_level1)} anomaly test of level 1 (over {len(list_tests_level1)})."
+                    f"\n Your dataset also failed {len(list_tests_level1)-sum(list_tests_level1)} anomaly test of level 1 (over {len(list_tests_level1)}).",
                 )
 
             with open(resume_test_anomalies) as f:
@@ -565,7 +570,7 @@ class Dataset:
             len(list_tests_level1) - sum(list_tests_level1) > 0
         ) and not force_upload:  # if presence of anomalies of level 1
             print(
-                f"\n\n Your dataset failed {len(list_tests_level1)-sum(list_tests_level1)} anomaly test of level 1 (over {len(list_tests_level1)}); see details below. \n  Anomalies of level 1 block dataset uploading, but anyone can force it by setting the variable `force_upload` to True. \n You can inspect your metadata saved here {path_raw_audio.joinpath('file_metadata.csv')} using the notebook  /home/datawork-osmose/osmose-datarmor/notebooks/metadata_analyzer.ipynb. \n"
+                f"\n\n Your dataset failed {len(list_tests_level1)-sum(list_tests_level1)} anomaly test of level 1 (over {len(list_tests_level1)}); see details below. \n  Anomalies of level 1 block dataset uploading, but anyone can force it by setting the variable `force_upload` to True. \n You can inspect your metadata saved here {path_raw_audio.joinpath('file_metadata.csv')} using the notebook  /home/datawork-osmose/osmose-datarmor/notebooks/metadata_analyzer.ipynb. \n",
             )
 
             with open(resume_test_anomalies) as f:
@@ -580,7 +585,7 @@ class Dataset:
                 {
                     "filename": audio_metadata["filename"].values,
                     "timestamp": audio_metadata["timestamp"].values,
-                }
+                },
             )
             df.sort_values(by=["timestamp"], inplace=True)
             df.to_csv(path_raw_audio.joinpath("timestamp.csv"), index=False)
@@ -591,7 +596,7 @@ class Dataset:
             new_folder_name = path_raw_audio.parent.joinpath(
                 str(int(mean(audio_metadata["duration"].values)))
                 + "_"
-                + str(int(mean(audio_metadata["origin_sr"].values)))
+                + str(int(mean(audio_metadata["origin_sr"].values))),
             )
 
             if new_folder_name.exists():
@@ -609,7 +614,7 @@ class Dataset:
             if subset_path.is_file():
                 xx = pd.read_csv(subset_path, header=None).values
                 pd.DataFrame(
-                    [ff[0].replace("-", "_").replace(":", "_") for ff in xx]
+                    [ff[0].replace("-", "_").replace(":", "_") for ff in xx],
                 ).to_csv(subset_path, index=False, header=None)
                 chmod_if_needed(path=subset_path, mode=FPDEFAULT)
 
@@ -622,16 +627,16 @@ class Dataset:
                 "start_date": timestamp_csv[0],
                 "end_date": timestamp_csv[-1],
                 "audio_file_origin_duration": int(
-                    mean(audio_metadata["duration"].values)
+                    mean(audio_metadata["duration"].values),
                 ),
                 "audio_file_origin_volume": round(
-                    mean(audio_metadata["size"].values), 1
+                    mean(audio_metadata["size"].values), 1,
                 ),
                 "dataset_origin_volume": max(
-                    1, round(sum(audio_metadata["size"].values) / 1000)
+                    1, round(sum(audio_metadata["size"].values) / 1000),
                 ),  # cannot be inferior to 1 GB
                 "dataset_origin_duration": round(
-                    sum(audio_metadata["duration"].values)
+                    sum(audio_metadata["duration"].values),
                 ),
                 "is_built": True,
                 "audio_file_dataset_overlap": 0,
@@ -642,33 +647,33 @@ class Dataset:
             df["depth"] = self.depth
             df["dataset_sr"] = int(mean(audio_metadata["origin_sr"].values))
             df["audio_file_dataset_duration"] = int(
-                mean(audio_metadata["duration"].values)
+                mean(audio_metadata["duration"].values),
             )
             df.to_csv(path_raw_audio.joinpath("metadata.csv"), index=False)
             chmod_if_needed(path=path_raw_audio / "metadata.csv", mode=FPDEFAULT)
 
             for path, _, files in os.walk(self.path.joinpath(OSMOSE_PATH.auxiliary)):
                 for f in files:
-                    if f.endswith((".csv")):
+                    if f.endswith(".csv"):
                         print(
-                            f"\n Checking your timestamp format in {Path(path,f).name}"
+                            f"\n Checking your timestamp format in {Path(path,f).name}",
                         )
                         self._format_timestamp(Path(path, f), date_template, False)
 
             print("\n DONE ! your dataset is on OSmOSE platform !")
 
     def _write_timestamp_csv_from_audio_files(
-        self, audio_path: Path, date_template: str
+        self, audio_path: Path, date_template: str,
     ):
         supported_audio_files = [file.name for file in get_all_audio_files(audio_path)]
         filenames_with_timestamps = associate_timestamps(
-            audio_files=supported_audio_files, datetime_template=date_template
+            audio_files=supported_audio_files, datetime_template=date_template,
         )
         filenames_with_timestamps["timestamp"] = filenames_with_timestamps[
             "timestamp"
         ].apply(lambda t: strftime_osmose_format(t))
         filenames_with_timestamps.to_csv(
-            audio_path / "timestamp.csv", index=False, na_rep="NaN"
+            audio_path / "timestamp.csv", index=False, na_rep="NaN",
         )
         os.chmod(audio_path / "timestamp.csv", mode=FPDEFAULT)
 
@@ -686,16 +691,15 @@ class Dataset:
             dataF = pd.read_csv(cur_timestamp_not_formatted)
             for val_timestamp_not_formatted in dataF["timestamp"].values:
                 cur_timestamp_formatted, format_OK = self._format_timestamp(
-                    val_timestamp_not_formatted, date_template, True
+                    val_timestamp_not_formatted, date_template, True,
                 )
                 if format_OK:
                     print("-> Format OK \n")
                     return None
-                else:
-                    list_cur_timestamp_formatted.append(cur_timestamp_formatted)
+                list_cur_timestamp_formatted.append(cur_timestamp_formatted)
 
             print(
-                f"We reformatted timestamps in your file {cur_timestamp_not_formatted.name} \n"
+                f"We reformatted timestamps in your file {cur_timestamp_not_formatted.name} \n",
             )
             dataF["timestamp"] = list_cur_timestamp_formatted
 
@@ -712,7 +716,7 @@ class Dataset:
 
         try:
             datetime.strptime(
-                cur_timestamp_not_formatted, TIMESTAMP_FORMAT_AUDIO_FILE
+                cur_timestamp_not_formatted, TIMESTAMP_FORMAT_AUDIO_FILE,
             )
             cur_timestamp_formatted = cur_timestamp_not_formatted
             format_OK = True
@@ -721,17 +725,16 @@ class Dataset:
             if not already_printed_1:
                 already_printed_1 = True
                 print(
-                    f"Timestamp format {cur_timestamp_not_formatted} does not fit our template {TIMESTAMP_FORMAT_AUDIO_FILE} let's reformat it"
+                    f"Timestamp format {cur_timestamp_not_formatted} does not fit our template {TIMESTAMP_FORMAT_AUDIO_FILE} let's reformat it",
                 )
             if not date_template:
                 raise FileNotFoundError("You have to define a date_template please.")
-            else:
-                date_obj = datetime.strptime(
-                    cur_timestamp_not_formatted + self.timezone, date_template + "%z"
-                )
-                cur_timestamp_formatted = datetime.strftime(
-                    date_obj, TIMESTAMP_FORMAT_AUDIO_FILE
-                )
+            date_obj = datetime.strptime(
+                cur_timestamp_not_formatted + self.timezone, date_template + "%z",
+            )
+            cur_timestamp_formatted = datetime.strftime(
+                date_obj, TIMESTAMP_FORMAT_AUDIO_FILE,
+            )
 
         return cur_timestamp_formatted, format_OK
 
@@ -746,15 +749,16 @@ class Dataset:
         - If there is only one folder in the raw audio path, then return it as the original.
         If none of the above is true, then a ValueError is raised as the original folder could not be found nor created.
 
-            Returns
-            -------
+        Returns
+        -------
                 original_folder: `Path`
                     The path to the folder containing the original files.
 
-            Raises
-            ------
+        Raises
+        ------
                 ValueError
                     If the original folder is not found and could not be created.
+
         """
         path_raw_audio = self.path / OSMOSE_PATH.raw_audio
         audio_files = []
@@ -768,8 +772,8 @@ class Dataset:
         for path, _, files in os.walk(self.path):
             for f in files:
                 if (
-                    not Path(path, f).parent.name == "original"
-                    and not Path(path, f).parent.name == "auxiliary"
+                    Path(path, f).parent.name != "original"
+                    and Path(path, f).parent.name != "auxiliary"
                 ):
                     if f.endswith((".wav", ".WAV", ".mp3", ".flac", ".FLAC")):
                         audio_files.append(Path(path, f))
@@ -781,15 +785,15 @@ class Dataset:
                             )
                     elif f == "timestamp.csv":
                         Path(path, f).rename(
-                            path_raw_audio / "original" / "timestamp.csv"
+                            path_raw_audio / "original" / "timestamp.csv",
                         )
                     else:
                         for key_dico in self.dico_aux_substring:
                             if re.search(
-                                "|".join(self.dico_aux_substring[key_dico]), f
+                                "|".join(self.dico_aux_substring[key_dico]), f,
                             ):
                                 Path(path, f).rename(
-                                    self.path / OSMOSE_PATH.auxiliary / key_dico / f
+                                    self.path / OSMOSE_PATH.auxiliary / key_dico / f,
                                 )
 
         for audio in audio_files:
@@ -798,7 +802,7 @@ class Dataset:
         for parent_dir in parent_dir_list:
             if len(os.listdir(parent_dir)) > 0:
                 print(
-                    f"- Removing your subfolder: {parent_dir}, but be aware that you had the following non-wav data in your subfolder {parent_dir}: {os.listdir(parent_dir)} \n"
+                    f"- Removing your subfolder: {parent_dir}, but be aware that you had the following non-wav data in your subfolder {parent_dir}: {os.listdir(parent_dir)} \n",
                 )
             else:
                 print(f"- Removing your subfolder: {parent_dir}\n")
@@ -819,6 +823,7 @@ class Dataset:
         ------
             ValueError
                 If no metadata.csv has been found and the original folder is not able to be found.
+
         """
         # First, grab any metadata.csv
         all_datasets = self.path.joinpath(OSMOSE_PATH.raw_audio).iterdir()
@@ -829,7 +834,7 @@ class Dataset:
             except StopIteration:
                 # If we get to the end of the generator, it means that no metadata file has been found, so we raise a more explicit error.
                 raise ValueError(
-                    f"No metadata file found in {self.path.joinpath(OSMOSE_PATH.raw_audio, audio_dir)}. Impossible to find the original data file."
+                    f"No metadata file found in {self.path.joinpath(OSMOSE_PATH.raw_audio, audio_dir)}. Impossible to find the original data file.",
                 )
             if metadata_path.exists():
                 break
@@ -840,7 +845,7 @@ class Dataset:
         origin_sr = int(metadata["origin_sr"][0])
 
         self.__original_folder = self.path.joinpath(
-            OSMOSE_PATH.raw_audio, f"{audio_file_origin_duration}_{origin_sr}"
+            OSMOSE_PATH.raw_audio, f"{audio_file_origin_duration}_{origin_sr}",
         )
 
         return self.original_folder

--- a/src/OSmOSE/Dataset.py
+++ b/src/OSmOSE/Dataset.py
@@ -244,7 +244,7 @@ class Dataset:
             return
         if value:
             try:
-                gid = grp.getgrnam(value).gr_gid
+                grp.getgrnam(value).gr_gid
             except KeyError as e:
                 raise KeyError(
                     f"The group {value} does not exist on the system. Full error trace: {e}"
@@ -711,7 +711,7 @@ class Dataset:
                 date_template = date_template[:-1]
 
         try:
-            check_right_format = datetime.strptime(
+            datetime.strptime(
                 cur_timestamp_not_formatted, TIMESTAMP_FORMAT_AUDIO_FILE
             )
             cur_timestamp_formatted = cur_timestamp_not_formatted

--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -1,42 +1,41 @@
-from functools import partial
+import glob
 import inspect
+import itertools
+import multiprocessing as mp
 import os
 import shutil
 import sys
-from typing import Tuple, Union, Literal
+from datetime import datetime, timedelta
+from functools import partial
 from math import log10
 from pathlib import Path
-import multiprocessing as mp
-import glob
-from IPython.display import Image, display
+from typing import Literal, Tuple, Union
 
-from tqdm import tqdm
-import itertools
-
-from datetime import timedelta, datetime
-
-import pandas as pd
 import numpy as np
+import pandas as pd
+from IPython.display import Image, display
+from matplotlib import pyplot as plt
 from scipy import signal
 from termcolor import colored
-from matplotlib import pyplot as plt
-from OSmOSE.job import Job_builder
+from tqdm import tqdm
+
 from OSmOSE.cluster import (
-    reshape,
     compute_stats,
     merge_timestamp_csv,
+    reshape,
 )
+from OSmOSE.config import DPDEFAULT, FPDEFAULT, OSMOSE_PATH
 from OSmOSE.Dataset import Dataset
-from OSmOSE.utils.path_utils import make_path
+from OSmOSE.frequency_scales.frequency_scale_serializer import FrequencyScaleSerializer
+from OSmOSE.job import Job_builder
+from OSmOSE.utils.audio_utils import get_all_audio_files
 from OSmOSE.utils.core_utils import (
+    chmod_if_needed,
+    get_timestamp_of_audio_file,
     safe_read,
     set_umask,
-    get_timestamp_of_audio_file,
-    chmod_if_needed,
 )
-from OSmOSE.utils.audio_utils import get_all_audio_files
-from OSmOSE.config import OSMOSE_PATH, FPDEFAULT, DPDEFAULT
-from OSmOSE.frequency_scales.frequency_scale_serializer import FrequencyScaleSerializer
+from OSmOSE.utils.path_utils import make_path
 
 
 class Spectrogram(Dataset):
@@ -105,6 +104,7 @@ class Spectrogram(Dataset):
         local : `bool`, optional, keyword_only
             Indicates whether or not the program is run locally. If it is the case, it will not create jobs and will handle the paralelisation
             alone. The default is False.
+
         """
         super().__init__(
             dataset_path=dataset_path,
@@ -114,7 +114,7 @@ class Spectrogram(Dataset):
         self.__local = local
 
         orig_metadata = pd.read_csv(
-            self._get_original_after_build() / "metadata.csv", header=0
+            self._get_original_after_build() / "metadata.csv", header=0,
         )
 
         processed_path = self.path / OSMOSE_PATH.spectrogram
@@ -131,7 +131,7 @@ class Spectrogram(Dataset):
             analysis_sheet = {}
             self.__analysis_file = False
             print(
-                "No valid processed/adjust_metadata.csv found and no parameters provided. All attributes will be initialized to default values..  \n"
+                "No valid processed/adjust_metadata.csv found and no parameters provided. All attributes will be initialized to default values..  \n",
             )
 
         self.batch_number: int = batch_number
@@ -249,7 +249,7 @@ class Spectrogram(Dataset):
 
     @classmethod
     def from_csv(
-        cls, dataset_path: Path, metadata_csv_path: Path
+        cls, dataset_path: Path, metadata_csv_path: Path,
     ):  # I don't want to use the dataset_path, but for now I have to
         df = pd.read_csv(metadata_csv_path)
         instance = cls(dataset_path=dataset_path)
@@ -362,7 +362,7 @@ class Spectrogram(Dataset):
             self.__audio_file_overlap = value
         else:
             raise ValueError(
-                "Segmented audio file overlapping value must be smaller than spectro_duration"
+                "Segmented audio file overlapping value must be smaller than spectro_duration",
             )
 
     @property
@@ -463,7 +463,7 @@ class Spectrogram(Dataset):
         self.__custom_frequency_scale = value
 
     def __build_path(
-        self, adjust: bool = False, dry: bool = False, force_init: bool = False
+        self, adjust: bool = False, dry: bool = False, force_init: bool = False,
     ):
         """Build some internal paths according to the expected architecture and might create them.
 
@@ -476,10 +476,10 @@ class Spectrogram(Dataset):
         """
         set_umask()
         processed_path = self.path / OSMOSE_PATH.spectrogram
-        audio_foldername = f"{str(self.spectro_duration)}_{str(self.dataset_sr)}"
+        audio_foldername = f"{self.spectro_duration!s}_{self.dataset_sr!s}"
         self.audio_path = self.path / OSMOSE_PATH.raw_audio / audio_foldername
 
-        self.__spectro_foldername = f"{str(self.nfft)}_{str(self.window_size)}_{str(self.overlap)}_{self.custom_frequency_scale}"
+        self.__spectro_foldername = f"{self.nfft!s}_{self.window_size!s}_{self.overlap!s}_{self.custom_frequency_scale}"
 
         self.path_output_spectrogram = (
             processed_path / audio_foldername / self.__spectro_foldername / "image"
@@ -501,14 +501,14 @@ class Spectrogram(Dataset):
         if not dry:
             if self.audio_path.exists() and force_init:
                 print(
-                    f"removing existing directory {self.audio_path}.. this can take a bit of time"
+                    f"removing existing directory {self.audio_path}.. this can take a bit of time",
                 )
                 shutil.rmtree(self.audio_path)
             make_path(self.audio_path, mode=DPDEFAULT)
 
             if self.path_output_spectrogram.exists() and force_init:
                 print(
-                    f"removing existing directory {self.path_output_spectrogram}.. this can take a bit of time"
+                    f"removing existing directory {self.path_output_spectrogram}.. this can take a bit of time",
                 )
                 shutil.rmtree(self.path_output_spectrogram)
             make_path(self.path_output_spectrogram, mode=DPDEFAULT)
@@ -540,13 +540,13 @@ class Spectrogram(Dataset):
                 colored(
                     "Note that unless you have a 4K screen, unwanted numerical compression might occur when visualizing your spectrograms..",
                     "red",
-                )
+                ),
             )
 
         temporal_resolution, frequency_resolution, Nbwin = self.extract_spectro_params()
 
         print(
-            f"your smallest tile has a duration of: {self.spectro_duration / 2 ** (self.zoom_level)} (s), with a number of spectra of {Nbwin} \n"
+            f"your smallest tile has a duration of: {self.spectro_duration / 2 ** (self.zoom_level)} (s), with a number of spectra of {Nbwin} \n",
         )
 
         if Nbwin > 3500:
@@ -554,7 +554,7 @@ class Spectrogram(Dataset):
                 colored(
                     "Note that unless you have a 4K screen, unwanted numerical compression might occur when visualizing your spectrograms..",
                     "red",
-                )
+                ),
             )
 
         print("\n")
@@ -602,8 +602,8 @@ class Spectrogram(Dataset):
             Force every parameter of the initialization.
         threshold : int, optional
             Integer from 0 to 100 to filter out segments with a number of sample inferior to (threshold * spectrogram duration * segment_sample_rate)
-        """
 
+        """
         # remove temp directories from adjustment spectrograms
         for path in glob.glob(str(self.path / OSMOSE_PATH.raw_audio / "temp_*")):
             shutil.rmtree(path)
@@ -656,7 +656,7 @@ class Spectrogram(Dataset):
         audio_metadata_path = (
             self.path
             / OSMOSE_PATH.raw_audio
-            / f"{str(self.spectro_duration)}_{str(self.dataset_sr)}"
+            / f"{self.spectro_duration!s}_{self.dataset_sr!s}"
             / "metadata.csv"
         )
         audio_file_origin_duration = file_metadata["duration"]
@@ -668,7 +668,7 @@ class Spectrogram(Dataset):
 
         if audio_metadata_path.exists():
             print(
-                "It seems these spectrogram parameters are already initialized. If it is an error or you want to rerun the initialization, add the `force_init` argument."
+                "It seems these spectrogram parameters are already initialized. If it is an error or you want to rerun the initialization, add the `force_init` argument.",
             )
             return
 
@@ -679,13 +679,13 @@ class Spectrogram(Dataset):
                 header=None,
             )[0].values
             self.list_audio_to_process = list(
-                set(subset).intersection(set(self.list_audio_to_process))
+                set(subset).intersection(set(self.list_audio_to_process)),
             )
 
         # if datetime begin/end are not provided, takes the datetime of first audio file/datetime + duration of last audio file
         if not datetime_begin:
             datetime_begin = (file_metadata["timestamp"].iloc[0]).strftime(
-                "%Y-%m-%dT%H:%M:%S%z"
+                "%Y-%m-%dT%H:%M:%S%z",
             )
 
         if not datetime_end:
@@ -697,7 +697,7 @@ class Spectrogram(Dataset):
         # check datetimes
         if not pd.Timestamp(datetime_begin) < pd.Timestamp(datetime_end):
             raise ValueError(
-                f"'datetime_begin' must be anterior to 'datetime_end'.\ndatetime_begin is set to {pd.Timestamp(datetime_begin)} and datetime_end is set to {pd.Timestamp(datetime_end)}"
+                f"'datetime_begin' must be anterior to 'datetime_end'.\ndatetime_begin is set to {pd.Timestamp(datetime_begin)} and datetime_end is set to {pd.Timestamp(datetime_end)}",
             )
 
         # new timestamps calculation to determine the size of a batch
@@ -717,7 +717,7 @@ class Spectrogram(Dataset):
                 counter = 0
                 current_ts = ts
                 original_timedelta = pd.Timedelta(
-                    seconds=selected_file_metadata["duration"].iloc[i]
+                    seconds=selected_file_metadata["duration"].iloc[i],
                 )
 
                 while current_ts <= ts + original_timedelta:
@@ -737,7 +737,7 @@ class Spectrogram(Dataset):
             self.dataset_sr != origin_sr
         ):
             print(
-                f"Automatically reshaping audio files to fit the spectro duration value. Files will be {self.spectro_duration} seconds long. Parameter 'concat' is set to {self.concat}."
+                f"Automatically reshaping audio files to fit the spectro duration value. Files will be {self.spectro_duration} seconds long. Parameter 'concat' is set to {self.concat}.",
             )
 
             input_files = self.path_input_audio_file
@@ -841,16 +841,16 @@ class Spectrogram(Dataset):
                 list_conca_filename.append(list(pd.read_csv(ll)["filename"].values))
                 os.remove(ll)
 
-            print(f"save file {str(input_dir_path / 'timestamp.csv')}")
+            print(f"save file {input_dir_path / 'timestamp.csv'!s}")
             df = pd.DataFrame(
                 {
                     "filename": list(
-                        itertools.chain.from_iterable(list_conca_filename)
+                        itertools.chain.from_iterable(list_conca_filename),
                     ),
                     "timestamp": list(
-                        itertools.chain.from_iterable(list_conca_timestamps)
+                        itertools.chain.from_iterable(list_conca_timestamps),
                     ),
-                }
+                },
             )
             df.sort_values(by=["timestamp"], inplace=True)
             df.to_csv(input_dir_path / "timestamp.csv", index=False)
@@ -913,7 +913,7 @@ class Spectrogram(Dataset):
         metadata["audio_file_dataset_overlap"] = self.audio_file_overlap
 
         origin_dt = pd.read_csv(
-            self.path_input_audio_file / "timestamp.csv", parse_dates=["timestamp"]
+            self.path_input_audio_file / "timestamp.csv", parse_dates=["timestamp"],
         )["timestamp"]
 
         metadata["audio_file_count"] = sum(
@@ -972,8 +972,8 @@ class Spectrogram(Dataset):
             meta_path = (
                 self.path
                 / OSMOSE_PATH.spectrogram
-                / f"{str(self.spectro_duration)}_{str(self.dataset_sr)}"
-                / f"{str(self.nfft)}_{str(self.window_size)}_{str(self.overlap)}_{self.custom_frequency_scale}"
+                / f"{self.spectro_duration!s}_{self.dataset_sr!s}"
+                / f"{self.nfft!s}_{self.window_size!s}_{self.overlap!s}_{self.custom_frequency_scale}"
                 / "metadata.csv"
             )
 
@@ -991,13 +991,12 @@ class Spectrogram(Dataset):
 
         if csv_path.exists():
             return csv_path
-        else:
-            with open(csv_path, "w") as f:
-                f.write("\n".join([str(audio) for audio in list_audio]))
+        with open(csv_path, "w") as f:
+            f.write("\n".join([str(audio) for audio in list_audio]))
 
-            chmod_if_needed(path=csv_path, mode=FPDEFAULT)
+        chmod_if_needed(path=csv_path, mode=FPDEFAULT)
 
-            return csv_path
+        return csv_path
 
     def update_parameters(self, filename: Path) -> bool:
         """Read the csv file filename and compare it to the spectrogram parameters. If any parameter is different, the file will be replaced and the fields changed.
@@ -1011,8 +1010,9 @@ class Spectrogram(Dataset):
 
         Returns
         -------
-            True if the parameters were updated else False."""
+            True if the parameters were updated else False.
 
+        """
         if not filename.suffix == ".csv":
             raise ValueError("The file must be a .csv file to be updated.")
 
@@ -1049,7 +1049,7 @@ class Spectrogram(Dataset):
             pd.DataFrame.from_records([new_params]).to_csv(filename, index=False)
 
             chmod_if_needed(
-                path=filename, mode=FPDEFAULT
+                path=filename, mode=FPDEFAULT,
             )  # This was DPDEFAULT: was it intentional?
             return True
 
@@ -1060,13 +1060,13 @@ class Spectrogram(Dataset):
                 param not in orig_params
                 or str(orig_params[param]) != str(new_params[param])
                 for param in new_params
-            ]
+            ],
         ):
             filename.unlink()
             pd.DataFrame.from_records([new_params]).to_csv(filename, index=False)
 
             chmod_if_needed(
-                path=filename, mode=FPDEFAULT
+                path=filename, mode=FPDEFAULT,
             )  # This was DPDEFAULT: was it intentional?
             return True
         return False
@@ -1095,6 +1095,7 @@ class Spectrogram(Dataset):
             If set to False, will skip the processing if all output files already exist. If set to True, will first delete the existing files before processing.
         clean_adjust_folder: `bool`, optional, keyword-only
             Whether the adjustment folder should be deleted.
+
         """
         if adjust:
             audio_file = Path(audio_file)
@@ -1127,9 +1128,8 @@ class Spectrogram(Dataset):
                     print("adjustment_spectros folder deleted.")
             except Exception as e:
                 print(
-                    f"Cannot remove adjustment_spectros folder. Description of the error : {str(e.value)}"
+                    f"Cannot remove adjustment_spectros folder. Description of the error : {e.value!s}",
                 )
-                pass
 
             self.save_matrix = save_matrix
             self.save_for_LTAS = save_for_LTAS
@@ -1145,26 +1145,26 @@ class Spectrogram(Dataset):
             if overwrite:
                 if any(self.path_output_spectrogram.glob(f"{Path(audio_file).stem}*")):
                     print(
-                        f"Existing spectrogram files detected for audio file {audio_file}! 'overwrite' is set to {overwrite}, they will be overwritten."
+                        f"Existing spectrogram files detected for audio file {audio_file}! 'overwrite' is set to {overwrite}, they will be overwritten.",
                     )
                 for old_file in self.path_output_spectrogram.glob(
-                    f"{Path(audio_file).stem}*"
+                    f"{Path(audio_file).stem}*",
                 ):
                     old_file.unlink()
                 if save_matrix:
                     for old_matrix in self.path_output_spectrogram_matrix.glob(
-                        f"{Path(audio_file).stem}*"
+                        f"{Path(audio_file).stem}*",
                     ):
                         old_matrix.unlink()
             else:
                 print(
-                    f"The spectrograms for the file {audio_file} have already been generated, skipping..."
+                    f"The spectrograms for the file {audio_file} have already been generated, skipping...",
                 )
                 return
 
             if audio_file not in os.listdir(self.audio_path):
                 raise FileNotFoundError(
-                    f"The file {audio_file} must be in {self.audio_path} in order to be processed."
+                    f"The file {audio_file} must be in {self.audio_path} in order to be processed.",
                 )
 
             """
@@ -1223,7 +1223,7 @@ class Spectrogram(Dataset):
                 [
                     max(self.hp_filter_min_freq, sys.float_info.epsilon),
                     sample_rate / 2 - 1,
-                ]
+                ],
             ),
             fs=sample_rate,
             output="sos",
@@ -1233,11 +1233,11 @@ class Spectrogram(Dataset):
 
         print(f"Generating spectrograms for {output_file.name}")
         self.gen_tiles(
-            data=data, sample_rate=sample_rate, output_file=output_file, adjust=adjust
+            data=data, sample_rate=sample_rate, output_file=output_file, adjust=adjust,
         )
 
     def gen_tiles(
-        self, *, data: np.ndarray, sample_rate: int, output_file: Path, adjust: bool
+        self, *, data: np.ndarray, sample_rate: int, output_file: Path, adjust: bool,
     ):
         """Generate spectrogram tiles corresponding to the zoom levels.
 
@@ -1248,8 +1248,9 @@ class Spectrogram(Dataset):
         sample_rate : `int`
             The sample rate of the audio data.
         output_file : `str`
-            The name of the output spectrogram."""
+            The name of the output spectrogram.
 
+        """
         if self.data_normalization == "zscore" and self.zscore_duration:
             if (len(self.zscore_duration) > 0) and (self.zscore_duration != "original"):
                 data = (data - self.__zscore_mean) / self.__zscore_std
@@ -1261,7 +1262,7 @@ class Spectrogram(Dataset):
                 f"- data min : {np.min(data):.3f}\n"
                 f"- data max : {np.max(data):.3f}\n"
                 f"- data mean : {np.mean(data):.3f}\n"
-                f"- data std : {np.std(data):.3f}\n"
+                f"- data std : {np.std(data):.3f}\n",
             )
 
         duration = len(data) / int(sample_rate)
@@ -1276,20 +1277,20 @@ class Spectrogram(Dataset):
                 get_timestamp_of_audio_file(
                     self.audio_path / "timestamp.csv",
                     audio_file_name + audio_file_ext,
-                )
+                ),
             )
             list_timestamps = []
 
         Sxx_complete_lowest_level = np.empty((int(self.nfft / 2) + 1, 1))
         Sxx_mean_lowest_tuile = np.empty((1, int(self.nfft / 2) + 1))
 
-        for tile in range(0, nber_tiles_lowest_zoom_level):
+        for tile in range(nber_tiles_lowest_zoom_level):
             start = tile * tile_duration
             end = start + tile_duration
 
             if not adjust:
                 list_timestamps.append(
-                    current_timestamp + timedelta(seconds=int(start))
+                    current_timestamp + timedelta(seconds=int(start)),
                 )
 
             sample_data = data[int(start * sample_rate) : int(end * sample_rate) - 1]
@@ -1298,19 +1299,19 @@ class Spectrogram(Dataset):
                 data=sample_data,
                 sample_rate=sample_rate,
                 output_file=output_file.parent
-                / f"{output_file.stem}_{nber_tiles_lowest_zoom_level}_{str(tile)}.png",
+                / f"{output_file.stem}_{nber_tiles_lowest_zoom_level}_{tile!s}.png",
             )
 
             Sxx_complete_lowest_level = np.hstack((Sxx_complete_lowest_level, Sxx))
             Sxx_mean_lowest_tuile = np.vstack(
-                (Sxx_mean_lowest_tuile, Sxx.mean(axis=1)[np.newaxis, :])
+                (Sxx_mean_lowest_tuile, Sxx.mean(axis=1)[np.newaxis, :]),
             )
 
         Sxx_complete_lowest_level = Sxx_complete_lowest_level[:, 1:]
         Sxx_mean_lowest_tuile = Sxx_mean_lowest_tuile[1:, :]
 
         segment_times = np.linspace(
-            0, len(data) / sample_rate, Sxx_complete_lowest_level.shape[1]
+            0, len(data) / sample_rate, Sxx_complete_lowest_level.shape[1],
         )[np.newaxis, :]
 
         # lowest tuile resolution
@@ -1347,11 +1348,11 @@ class Spectrogram(Dataset):
             # loop over the tiles at each zoom level
             for tile in range(2**zoom_level):
                 Sxx_int = Sxx_complete_lowest_level[
-                    :, tile * nberspec : (tile + 1) * nberspec
+                    :, tile * nberspec : (tile + 1) * nberspec,
                 ][:, :: 2 ** (self.zoom_level - zoom_level)]
 
                 segment_times_int = segment_times[
-                    :, tile * nberspec : (tile + 1) * nberspec
+                    :, tile * nberspec : (tile + 1) * nberspec,
                 ][:, :: 2 ** (self.zoom_level - zoom_level)]
 
                 if self.spectro_normalization == "density":
@@ -1364,7 +1365,7 @@ class Spectrogram(Dataset):
                     freq=Freq,
                     log_spectro=log_spectro,
                     output_file=output_file.parent
-                    / f"{output_file.stem}_{str(2 ** zoom_level)}_{str(tile)}.png",
+                    / f"{output_file.stem}_{2 ** zoom_level!s}_{tile!s}.png",
                     adjust=adjust,
                 )
 
@@ -1397,7 +1398,7 @@ class Spectrogram(Dataset):
                     chmod_if_needed(path=output_matrix, mode=FPDEFAULT)
 
     def gen_spectro(
-        self, *, data: np.ndarray, sample_rate: int, output_file: Path
+        self, *, data: np.ndarray, sample_rate: int, output_file: Path,
     ) -> Tuple[np.ndarray, np.ndarray[float]]:
         """Generate the spectrograms
 
@@ -1414,8 +1415,8 @@ class Spectrogram(Dataset):
         -------
         Sxx : `np.NDArray[float64]`
         Freq : `np.NDArray[float]`
-        """
 
+        """
         Noverlap = int(self.window_size * self.overlap / 100)
 
         win = np.hamming(self.window_size)
@@ -1502,8 +1503,9 @@ class Spectrogram(Dataset):
         freq : `np.NDArray[floating]`
         log_spectro : `np.NDArray[signed int]`
         output_file : `str`
-            The name of the spectrogram file."""
+            The name of the spectrogram file.
 
+        """
         # Plotting spectrogram
         my_dpi = 100
         fact_x = 1.3
@@ -1517,24 +1519,23 @@ class Spectrogram(Dataset):
         if self.verbose:
             print(
                 f"- min log spectro : {np.amin(log_spectro):.3f}\n"
-                f"- max log spectro : {np.amax(log_spectro):.3f}\n"
+                f"- max log spectro : {np.amax(log_spectro):.3f}\n",
             )
 
         color_map = plt.get_cmap(self.colormap)
 
         if self.custom_frequency_scale == "linear":
             plt.pcolormesh(time, freq, log_spectro, cmap=color_map)
+        elif self.custom_frequency_scale == "log":
+            plt.pcolormesh(time, freq, log_spectro, cmap=color_map)
+            plt.yscale("log")
+            plt.ylim(freq[freq > 0].min(), self.dataset_sr / 2)
         else:
-            if self.custom_frequency_scale == "log":
-                plt.pcolormesh(time, freq, log_spectro, cmap=color_map)
-                plt.yscale("log")
-                plt.ylim(freq[freq > 0].min(), self.dataset_sr / 2)
-            else:
-                custom_frequency_scale = FrequencyScaleSerializer().get_scale(
-                    self.custom_frequency_scale, self.dataset_sr
-                )
-                freq_custom = np.vectorize(custom_frequency_scale.map_freq2scale)(freq)
-                plt.pcolormesh(time, freq_custom, log_spectro, cmap=color_map)
+            custom_frequency_scale = FrequencyScaleSerializer().get_scale(
+                self.custom_frequency_scale, self.dataset_sr,
+            )
+            freq_custom = np.vectorize(custom_frequency_scale.map_freq2scale)(freq)
+            plt.pcolormesh(time, freq_custom, log_spectro, cmap=color_map)
 
         plt.clim(vmin=self.dynamic_min, vmax=self.dynamic_max)
 
@@ -1572,7 +1573,6 @@ class Spectrogram(Dataset):
         """Process all the files in the dataset and generates the spectrograms. It uses the python multiprocessing library
         to parallelise the computation, so it is less efficient to use this method rather than the job scheduler if run on a cluster.
         """
-
         if len(list_audio_to_process) > 0:
             self.list_audio_to_process = list_audio_to_process
 
@@ -1610,7 +1610,7 @@ class Spectrogram(Dataset):
                 Time = list(itertools.chain(*Time))
 
             np.savez(
-                path_all_welch, Sxx=Sxx, Time=Time, Freq=Freq, allow_pickle=True
+                path_all_welch, Sxx=Sxx, Time=Time, Freq=Freq, allow_pickle=True,
             )  # careful data not sorted here! we should save them based on dataframe df below
 
         else:
@@ -1627,88 +1627,87 @@ class Spectrogram(Dataset):
         show_fig: bool = False,
     ):
         list_npz_files = list(
-            (self.path_output_welch / f"{time_resolution}_{sample_rate}").glob("*npz")
+            (self.path_output_welch / f"{time_resolution}_{sample_rate}").glob("*npz"),
         )
 
         if len(list_npz_files) == 0:
             raise FileNotFoundError(
-                f"No intermediary welch spectra to aggregate in the folder {self.path_output_welch / f'{time_resolution}_{sample_rate}'} ; please run a complete generation of spectrograms first!"
+                f"No intermediary welch spectra to aggregate in the folder {self.path_output_welch / f'{time_resolution}_{sample_rate}'} ; please run a complete generation of spectrograms first!",
+            )
+
+        if not self.path_output_LTAS.exists():
+            make_path(self.path_output_LTAS, mode=DPDEFAULT)
+
+        path_all_welch = (
+            self.path_output_welch
+            / f"{time_resolution}_{sample_rate}"
+            / "all_welch.npz"
+        )
+
+        if os.path.exists(path_all_welch):
+            data = np.load(path_all_welch, allow_pickle=True)
+            Sxx = data["Sxx"]
+            Time = data["Time"]
+            Freq = data["Freq"]
+        else:
+            Sxx, Time, Freq = self.save_all_welch(list_npz_files, path_all_welch)
+
+        # convert numpy arrays to dataframe, more convenient for time operations
+        df = pd.DataFrame(Sxx, dtype=float)
+        df["Time"] = Time
+        # sort by time, and make time variable as dataframe index
+        df.sort_values(by=["Time"], inplace=True)
+        df.set_index("Time", inplace=True, drop=True)
+        df.index = pd.to_datetime(df.index)
+
+        if time_scale == "all":
+            cur_LTAS = df.values
+
+            if self.spectro_normalization == "density":
+                log_spectro = 10 * np.log10((cur_LTAS / (1e-12)) + (1e-100))
+            if self.spectro_normalization == "spectrum":
+                log_spectro = 10 * np.log10(cur_LTAS + (1e-100))
+
+            self.generate_and_save_LTAS(
+                start_time=df.index[0],
+                end_time=df.index[-1],
+                freq=Freq,
+                log_spectro=log_spectro.T,
+                output_file=self.path / OSMOSE_PATH.LTAS / "LTAS_all.png",
+                time_scale="all",
+                raw_time_vector=df.index,
+                show_fig=show_fig,
             )
 
         else:
-            if not self.path_output_LTAS.exists():
-                make_path(self.path_output_LTAS, mode=DPDEFAULT)
+            time_vector = pd.date_range(Time[0], Time[-1], freq=time_scale)
 
-            path_all_welch = (
-                self.path_output_welch
-                / f"{time_resolution}_{sample_rate}"
-                / "all_welch.npz"
-            )
+            for ind_period in range(len(time_vector) - 1):
+                current_df = df[
+                    (df.index > time_vector[ind_period])
+                    & (df.index <= time_vector[ind_period + 1])
+                ]
 
-            if os.path.exists(path_all_welch):
-                data = np.load(path_all_welch, allow_pickle=True)
-                Sxx = data["Sxx"]
-                Time = data["Time"]
-                Freq = data["Freq"]
-            else:
-                Sxx, Time, Freq = self.save_all_welch(list_npz_files, path_all_welch)
-
-            # convert numpy arrays to dataframe, more convenient for time operations
-            df = pd.DataFrame(Sxx, dtype=float)
-            df["Time"] = Time
-            # sort by time, and make time variable as dataframe index
-            df.sort_values(by=["Time"], inplace=True)
-            df.set_index("Time", inplace=True, drop=True)
-            df.index = pd.to_datetime(df.index)
-
-            if time_scale == "all":
-                cur_LTAS = df.values
+                current_time_period = current_df.index
+                cur_LTAS = current_df.values.T
 
                 if self.spectro_normalization == "density":
-                    log_spectro = 10 * np.log10((cur_LTAS / (1e-12)) + (1e-100))
+                    log_spectro = 10 * np.log10((cur_LTAS / (1e-12)) + (1e-20))
                 if self.spectro_normalization == "spectrum":
-                    log_spectro = 10 * np.log10(cur_LTAS + (1e-100))
+                    log_spectro = 10 * np.log10(cur_LTAS + (1e-20))
 
                 self.generate_and_save_LTAS(
-                    start_time=df.index[0],
-                    end_time=df.index[-1],
+                    start_time=current_time_period[0],
+                    end_time=current_time_period[-1],
                     freq=Freq,
-                    log_spectro=log_spectro.T,
-                    output_file=self.path / OSMOSE_PATH.LTAS / "LTAS_all.png",
-                    time_scale="all",
-                    raw_time_vector=df.index,
+                    log_spectro=log_spectro,
+                    output_file=self.path
+                    / OSMOSE_PATH.LTAS
+                    / f"LTAS_{datetime.strftime(time_vector[ind_period], '%Y_%m_%dT%H_%M_%S')}.png",
+                    time_scale=time_scale,
+                    raw_time_vector=current_time_period,
                     show_fig=show_fig,
                 )
-
-            else:
-                time_vector = pd.date_range(Time[0], Time[-1], freq=time_scale)
-
-                for ind_period in range(len(time_vector) - 1):
-                    current_df = df[
-                        (df.index > time_vector[ind_period])
-                        & (df.index <= time_vector[ind_period + 1])
-                    ]
-
-                    current_time_period = current_df.index
-                    cur_LTAS = current_df.values.T
-
-                    if self.spectro_normalization == "density":
-                        log_spectro = 10 * np.log10((cur_LTAS / (1e-12)) + (1e-20))
-                    if self.spectro_normalization == "spectrum":
-                        log_spectro = 10 * np.log10(cur_LTAS + (1e-20))
-
-                    self.generate_and_save_LTAS(
-                        start_time=current_time_period[0],
-                        end_time=current_time_period[-1],
-                        freq=Freq,
-                        log_spectro=log_spectro,
-                        output_file=self.path
-                        / OSMOSE_PATH.LTAS
-                        / f"LTAS_{datetime.strftime(time_vector[ind_period], '%Y_%m_%dT%H_%M_%S')}.png",
-                        time_scale=time_scale,
-                        raw_time_vector=current_time_period,
-                        show_fig=show_fig,
-                    )
 
     def generate_and_save_LTAS(
         self,
@@ -1780,199 +1779,197 @@ class Spectrogram(Dataset):
         show_fig: bool = False,
     ):
         list_npz_files = list(
-            (self.path_output_welch / f"{time_resolution}_{sample_rate}").glob("*npz")
+            (self.path_output_welch / f"{time_resolution}_{sample_rate}").glob("*npz"),
         )
 
         if len(list_npz_files) == 0:
             raise FileNotFoundError(
-                "No intermediary welch spectra to aggregate, run a complete generation of spectrograms first!"
+                "No intermediary welch spectra to aggregate, run a complete generation of spectrograms first!",
             )
 
-        else:
 
-            # assign default value for Freq_max, equivalent to no HF filtering
-            freq_max = [int(sample_rate / 2)]
-            if not isinstance(freq_min, list):
-                freq_min = [freq_min]
+        # assign default value for Freq_max, equivalent to no HF filtering
+        freq_max = [int(sample_rate / 2)]
+        if not isinstance(freq_min, list):
+            freq_min = [freq_min]
 
-            if not self.path_output_SPLfiltered.exists():
-                make_path(self.path_output_SPLfiltered, mode=DPDEFAULT)
+        if not self.path_output_SPLfiltered.exists():
+            make_path(self.path_output_SPLfiltered, mode=DPDEFAULT)
 
-            path_all_welch = (
-                self.path_output_welch
-                / f"{time_resolution}_{sample_rate}"
-                / "all_welch.npz"
-            )
-
-            if path_all_welch.exists():
-                data = np.load(path_all_welch, allow_pickle=True)
-                Sxx = data["Sxx"]
-                Time = data["Time"]
-                Freq = data["Freq"]
-            else:
-                Sxx, Time, Freq = self.save_all_welch(list_npz_files, path_all_welch)
-
-            # convert numpy arrays to dataframe, more convenient for time operations
-            df = pd.DataFrame(Sxx, dtype=float)
-            df["Time"] = Time
-            # sort by time, and make time variable as dataframe index
-            df.sort_values(by=["Time"], inplace=True)
-            df.set_index("Time", inplace=True, drop=True)
-            df.index = pd.to_datetime(df.index)
-
-            time_vector = pd.date_range(
-                df.index[0], df.index[-1], freq=str(time_resolution) + "s"
-            )
-
-            # Plotting SPL
-            my_dpi = 100
-            fact_x = 1.3
-            fact_y = 1.3
-            fig, ax = plt.subplots(
-                nrows=1,
-                ncols=1,
-                figsize=(fact_x * 1800 / my_dpi, fact_y * 512 / my_dpi),
-                dpi=my_dpi,
-            )
-
-            lst_legend = []
-            for cur_freq_min, cur_freq_max in zip(freq_min, freq_max):
-                pre_SPL = np.mean(
-                    df.values[
-                        :,
-                        np.argmin(abs(Freq - cur_freq_min)) : np.argmin(
-                            abs(Freq - cur_freq_max)
-                        ),
-                    ],
-                    1,
-                )
-
-                if self.spectro_normalization == "density":
-                    SPL_filtered = 10 * np.log10((pre_SPL / (1e-12)) + (1e-20))
-                if self.spectro_normalization == "spectrum":
-                    SPL_filtered = 10 * np.log10(pre_SPL + (1e-20))
-
-                plt.plot(np.arange(0, len(SPL_filtered)), SPL_filtered)
-                plt.autoscale(enable=True, axis="x", tight=True)
-
-                lst_legend.append(f"[{cur_freq_min}-{cur_freq_max}] Hz")
-
-                output_file_npz = (
-                    self.path
-                    / OSMOSE_PATH.SPLfiltered
-                    / f"SPLfiltered_{cur_freq_min}_{cur_freq_max}.npz"
-                )
-
-                np.savez(
-                    output_file_npz,
-                    SPL=SPL_filtered,
-                    time=time_vector,
-                    allow_pickle=True,
-                )
-
-            plt.ylabel("SPL (dB)")
-            plt.legend(lst_legend)
-
-            # write proper timestamps as xitck_labels
-            nber_xticks = min(10, len(SPL_filtered))
-            if (df.index[-1] - df.index[0]).days > 7:
-                label_smoother = "D"
-            else:
-                label_smoother = "h"
-            date = [p.to_period(label_smoother) for p in time_vector.tz_localize(None)]
-
-            int_sep = int(len(date) / nber_xticks)
-            plt.xticks(np.arange(0, len(date), int_sep), date[::int_sep])
-            ax.tick_params(axis="x", rotation=20)
-
-            # save as png figure
-            output_file = self.path / OSMOSE_PATH.SPLfiltered / "SPLfiltered.png"
-
-            print(
-                "Saving",
-                output_file,
-                "\nNumber of time points:",
-                str(len(SPL_filtered)),
-            )
-            plt.savefig(output_file, bbox_inches="tight", pad_inches=0)
-            plt.close()
-
-            if show_fig:
-                display(Image(filename=output_file))
-
-    def build_EPD(self, time_resolution: str, sample_rate: int, show_fig: bool = False):
-        list_npz_files = list(
-            (self.path_output_welch / f"{time_resolution}_{sample_rate}").glob("*npz")
+        path_all_welch = (
+            self.path_output_welch
+            / f"{time_resolution}_{sample_rate}"
+            / "all_welch.npz"
         )
-        if len(list_npz_files) == 0:
-            raise FileNotFoundError(
-                "No intermediary welch spectra to aggregate, run a complete generation of spectrograms first!"
-            )
 
+        if path_all_welch.exists():
+            data = np.load(path_all_welch, allow_pickle=True)
+            Sxx = data["Sxx"]
+            Time = data["Time"]
+            Freq = data["Freq"]
         else:
-            if not self.path_output_EPD.exists():
-                make_path(self.path_output_EPD, mode=DPDEFAULT)
+            Sxx, Time, Freq = self.save_all_welch(list_npz_files, path_all_welch)
 
-            path_all_welch = (
-                self.path_output_welch
-                / f"{time_resolution}_{sample_rate}"
-                / "all_welch.npz"
+        # convert numpy arrays to dataframe, more convenient for time operations
+        df = pd.DataFrame(Sxx, dtype=float)
+        df["Time"] = Time
+        # sort by time, and make time variable as dataframe index
+        df.sort_values(by=["Time"], inplace=True)
+        df.set_index("Time", inplace=True, drop=True)
+        df.index = pd.to_datetime(df.index)
+
+        time_vector = pd.date_range(
+            df.index[0], df.index[-1], freq=str(time_resolution) + "s",
+        )
+
+        # Plotting SPL
+        my_dpi = 100
+        fact_x = 1.3
+        fact_y = 1.3
+        fig, ax = plt.subplots(
+            nrows=1,
+            ncols=1,
+            figsize=(fact_x * 1800 / my_dpi, fact_y * 512 / my_dpi),
+            dpi=my_dpi,
+        )
+
+        lst_legend = []
+        for cur_freq_min, cur_freq_max in zip(freq_min, freq_max):
+            pre_SPL = np.mean(
+                df.values[
+                    :,
+                    np.argmin(abs(Freq - cur_freq_min)) : np.argmin(
+                        abs(Freq - cur_freq_max),
+                    ),
+                ],
+                1,
             )
 
-            if path_all_welch.exists():
-                data = np.load(path_all_welch, allow_pickle=True)
-                Sxx = data["Sxx"]
-                Time = data["Time"]
-                Freq = data["Freq"]
-            else:
-                Sxx, Time, Freq = self.save_all_welch(list_npz_files, path_all_welch)
+            if self.spectro_normalization == "density":
+                SPL_filtered = 10 * np.log10((pre_SPL / (1e-12)) + (1e-20))
+            if self.spectro_normalization == "spectrum":
+                SPL_filtered = 10 * np.log10(pre_SPL + (1e-20))
 
-            all_welch = 10 * np.log10(Sxx)
-
-            RMSlevel = 10 * np.log10(np.nanmean(10 ** (all_welch / 10), axis=0))
-
-            # Plotting SPL
-            my_dpi = 100
-            fact_x = 1.3
-            fact_y = 1.3
-            fig, ax = plt.subplots(
-                nrows=1,
-                ncols=1,
-                figsize=(fact_x * 1800 / my_dpi, fact_y * 512 / my_dpi),
-                dpi=my_dpi,
-            )
-
-            ax.plot(Freq, RMSlevel, color="k", label="RMS level")
-
-            percen = [1, 5, 50, 95, 99]
-            p = np.nanpercentile(all_welch, percen, 0, interpolation="linear")
-            for i in range(len(p)):
-                plt.plot(
-                    Freq, p[i, :], linewidth=2, label="%s %% percentil" % percen[i]
-                )
-
-            ax.semilogx()
-            plt.legend()
-            plt.autoscale(enable=True, axis="y", tight=True)
+            plt.plot(np.arange(0, len(SPL_filtered)), SPL_filtered)
             plt.autoscale(enable=True, axis="x", tight=True)
-            plt.ylabel("relative SPL (dB)")
-            plt.xlabel("Frequency (Hz)")
 
-            # save as png figure
-            output_file = self.path / OSMOSE_PATH.EPD / "EPD.png"
-            print(f"Saving {output_file}\nNumber of welch: {all_welch.shape[0]}")
-            plt.savefig(output_file, bbox_inches="tight", pad_inches=0)
-            plt.close()
+            lst_legend.append(f"[{cur_freq_min}-{cur_freq_max}] Hz")
 
-            output_file_npz = self.path / OSMOSE_PATH.EPD / "EPD.npz"
+            output_file_npz = (
+                self.path
+                / OSMOSE_PATH.SPLfiltered
+                / f"SPLfiltered_{cur_freq_min}_{cur_freq_max}.npz"
+            )
 
             np.savez(
                 output_file_npz,
-                Freq=Freq,
-                RMSlevel=RMSlevel,
-                percentiles=p,
+                SPL=SPL_filtered,
+                time=time_vector,
                 allow_pickle=True,
             )
 
-            if show_fig:
-                display(Image(filename=output_file))
+        plt.ylabel("SPL (dB)")
+        plt.legend(lst_legend)
+
+        # write proper timestamps as xitck_labels
+        nber_xticks = min(10, len(SPL_filtered))
+        if (df.index[-1] - df.index[0]).days > 7:
+            label_smoother = "D"
+        else:
+            label_smoother = "h"
+        date = [p.to_period(label_smoother) for p in time_vector.tz_localize(None)]
+
+        int_sep = int(len(date) / nber_xticks)
+        plt.xticks(np.arange(0, len(date), int_sep), date[::int_sep])
+        ax.tick_params(axis="x", rotation=20)
+
+        # save as png figure
+        output_file = self.path / OSMOSE_PATH.SPLfiltered / "SPLfiltered.png"
+
+        print(
+            "Saving",
+            output_file,
+            "\nNumber of time points:",
+            str(len(SPL_filtered)),
+        )
+        plt.savefig(output_file, bbox_inches="tight", pad_inches=0)
+        plt.close()
+
+        if show_fig:
+            display(Image(filename=output_file))
+
+    def build_EPD(self, time_resolution: str, sample_rate: int, show_fig: bool = False):
+        list_npz_files = list(
+            (self.path_output_welch / f"{time_resolution}_{sample_rate}").glob("*npz"),
+        )
+        if len(list_npz_files) == 0:
+            raise FileNotFoundError(
+                "No intermediary welch spectra to aggregate, run a complete generation of spectrograms first!",
+            )
+
+        if not self.path_output_EPD.exists():
+            make_path(self.path_output_EPD, mode=DPDEFAULT)
+
+        path_all_welch = (
+            self.path_output_welch
+            / f"{time_resolution}_{sample_rate}"
+            / "all_welch.npz"
+        )
+
+        if path_all_welch.exists():
+            data = np.load(path_all_welch, allow_pickle=True)
+            Sxx = data["Sxx"]
+            Time = data["Time"]
+            Freq = data["Freq"]
+        else:
+            Sxx, Time, Freq = self.save_all_welch(list_npz_files, path_all_welch)
+
+        all_welch = 10 * np.log10(Sxx)
+
+        RMSlevel = 10 * np.log10(np.nanmean(10 ** (all_welch / 10), axis=0))
+
+        # Plotting SPL
+        my_dpi = 100
+        fact_x = 1.3
+        fact_y = 1.3
+        fig, ax = plt.subplots(
+            nrows=1,
+            ncols=1,
+            figsize=(fact_x * 1800 / my_dpi, fact_y * 512 / my_dpi),
+            dpi=my_dpi,
+        )
+
+        ax.plot(Freq, RMSlevel, color="k", label="RMS level")
+
+        percen = [1, 5, 50, 95, 99]
+        p = np.nanpercentile(all_welch, percen, 0, interpolation="linear")
+        for i in range(len(p)):
+            plt.plot(
+                Freq, p[i, :], linewidth=2, label="%s %% percentil" % percen[i],
+            )
+
+        ax.semilogx()
+        plt.legend()
+        plt.autoscale(enable=True, axis="y", tight=True)
+        plt.autoscale(enable=True, axis="x", tight=True)
+        plt.ylabel("relative SPL (dB)")
+        plt.xlabel("Frequency (Hz)")
+
+        # save as png figure
+        output_file = self.path / OSMOSE_PATH.EPD / "EPD.png"
+        print(f"Saving {output_file}\nNumber of welch: {all_welch.shape[0]}")
+        plt.savefig(output_file, bbox_inches="tight", pad_inches=0)
+        plt.close()
+
+        output_file_npz = self.path / OSMOSE_PATH.EPD / "EPD.npz"
+
+        np.savez(
+            output_file_npz,
+            Freq=Freq,
+            RMSlevel=RMSlevel,
+            percentiles=p,
+            allow_pickle=True,
+        )
+
+        if show_fig:
+            display(Image(filename=output_file))

--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -889,7 +889,7 @@ class Spectrogram(Dataset):
                     process.start()
                     processes.append(process)
                 else:
-                    jobfile = self.jb.build_job_file(
+                    self.jb.build_job_file(
                         script_path=Path(inspect.getfile(compute_stats)).resolve(),
                         script_args=f"--input-dir {self.path_input_audio_file}\
                             --hp-filter-min-freq {self.hp_filter_min_freq}\
@@ -1582,7 +1582,7 @@ class Spectrogram(Dataset):
             "overwrite": True,
         }
 
-        map_process_file = partial(self.process_file, **kwargs)
+        partial(self.process_file, **kwargs)
 
         for ll in self.list_audio_to_process:
             self.process_file(ll, **kwargs)

--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -114,7 +114,8 @@ class Spectrogram(Dataset):
         self.__local = local
 
         orig_metadata = pd.read_csv(
-            self._get_original_after_build() / "metadata.csv", header=0,
+            self._get_original_after_build() / "metadata.csv",
+            header=0,
         )
 
         processed_path = self.path / OSMOSE_PATH.spectrogram
@@ -249,7 +250,9 @@ class Spectrogram(Dataset):
 
     @classmethod
     def from_csv(
-        cls, dataset_path: Path, metadata_csv_path: Path,
+        cls,
+        dataset_path: Path,
+        metadata_csv_path: Path,
     ):  # I don't want to use the dataset_path, but for now I have to
         df = pd.read_csv(metadata_csv_path)
         instance = cls(dataset_path=dataset_path)
@@ -463,7 +466,10 @@ class Spectrogram(Dataset):
         self.__custom_frequency_scale = value
 
     def __build_path(
-        self, adjust: bool = False, dry: bool = False, force_init: bool = False,
+        self,
+        adjust: bool = False,
+        dry: bool = False,
+        force_init: bool = False,
     ):
         """Build some internal paths according to the expected architecture and might create them.
 
@@ -913,7 +919,8 @@ class Spectrogram(Dataset):
         metadata["audio_file_dataset_overlap"] = self.audio_file_overlap
 
         origin_dt = pd.read_csv(
-            self.path_input_audio_file / "timestamp.csv", parse_dates=["timestamp"],
+            self.path_input_audio_file / "timestamp.csv",
+            parse_dates=["timestamp"],
         )["timestamp"]
 
         metadata["audio_file_count"] = sum(
@@ -1049,7 +1056,8 @@ class Spectrogram(Dataset):
             pd.DataFrame.from_records([new_params]).to_csv(filename, index=False)
 
             chmod_if_needed(
-                path=filename, mode=FPDEFAULT,
+                path=filename,
+                mode=FPDEFAULT,
             )  # This was DPDEFAULT: was it intentional?
             return True
 
@@ -1066,7 +1074,8 @@ class Spectrogram(Dataset):
             pd.DataFrame.from_records([new_params]).to_csv(filename, index=False)
 
             chmod_if_needed(
-                path=filename, mode=FPDEFAULT,
+                path=filename,
+                mode=FPDEFAULT,
             )  # This was DPDEFAULT: was it intentional?
             return True
         return False
@@ -1233,11 +1242,19 @@ class Spectrogram(Dataset):
 
         print(f"Generating spectrograms for {output_file.name}")
         self.gen_tiles(
-            data=data, sample_rate=sample_rate, output_file=output_file, adjust=adjust,
+            data=data,
+            sample_rate=sample_rate,
+            output_file=output_file,
+            adjust=adjust,
         )
 
     def gen_tiles(
-        self, *, data: np.ndarray, sample_rate: int, output_file: Path, adjust: bool,
+        self,
+        *,
+        data: np.ndarray,
+        sample_rate: int,
+        output_file: Path,
+        adjust: bool,
     ):
         """Generate spectrogram tiles corresponding to the zoom levels.
 
@@ -1311,7 +1328,9 @@ class Spectrogram(Dataset):
         Sxx_mean_lowest_tuile = Sxx_mean_lowest_tuile[1:, :]
 
         segment_times = np.linspace(
-            0, len(data) / sample_rate, Sxx_complete_lowest_level.shape[1],
+            0,
+            len(data) / sample_rate,
+            Sxx_complete_lowest_level.shape[1],
         )[np.newaxis, :]
 
         # lowest tuile resolution
@@ -1348,11 +1367,13 @@ class Spectrogram(Dataset):
             # loop over the tiles at each zoom level
             for tile in range(2**zoom_level):
                 Sxx_int = Sxx_complete_lowest_level[
-                    :, tile * nberspec : (tile + 1) * nberspec,
+                    :,
+                    tile * nberspec : (tile + 1) * nberspec,
                 ][:, :: 2 ** (self.zoom_level - zoom_level)]
 
                 segment_times_int = segment_times[
-                    :, tile * nberspec : (tile + 1) * nberspec,
+                    :,
+                    tile * nberspec : (tile + 1) * nberspec,
                 ][:, :: 2 ** (self.zoom_level - zoom_level)]
 
                 if self.spectro_normalization == "density":
@@ -1398,7 +1419,11 @@ class Spectrogram(Dataset):
                     chmod_if_needed(path=output_matrix, mode=FPDEFAULT)
 
     def gen_spectro(
-        self, *, data: np.ndarray, sample_rate: int, output_file: Path,
+        self,
+        *,
+        data: np.ndarray,
+        sample_rate: int,
+        output_file: Path,
     ) -> Tuple[np.ndarray, np.ndarray[float]]:
         """Generate the spectrograms
 
@@ -1532,7 +1557,8 @@ class Spectrogram(Dataset):
             plt.ylim(freq[freq > 0].min(), self.dataset_sr / 2)
         else:
             custom_frequency_scale = FrequencyScaleSerializer().get_scale(
-                self.custom_frequency_scale, self.dataset_sr,
+                self.custom_frequency_scale,
+                self.dataset_sr,
             )
             freq_custom = np.vectorize(custom_frequency_scale.map_freq2scale)(freq)
             plt.pcolormesh(time, freq_custom, log_spectro, cmap=color_map)
@@ -1610,7 +1636,11 @@ class Spectrogram(Dataset):
                 Time = list(itertools.chain(*Time))
 
             np.savez(
-                path_all_welch, Sxx=Sxx, Time=Time, Freq=Freq, allow_pickle=True,
+                path_all_welch,
+                Sxx=Sxx,
+                Time=Time,
+                Freq=Freq,
+                allow_pickle=True,
             )  # careful data not sorted here! we should save them based on dataframe df below
 
         else:
@@ -1787,7 +1817,6 @@ class Spectrogram(Dataset):
                 "No intermediary welch spectra to aggregate, run a complete generation of spectrograms first!",
             )
 
-
         # assign default value for Freq_max, equivalent to no HF filtering
         freq_max = [int(sample_rate / 2)]
         if not isinstance(freq_min, list):
@@ -1819,7 +1848,9 @@ class Spectrogram(Dataset):
         df.index = pd.to_datetime(df.index)
 
         time_vector = pd.date_range(
-            df.index[0], df.index[-1], freq=str(time_resolution) + "s",
+            df.index[0],
+            df.index[-1],
+            freq=str(time_resolution) + "s",
         )
 
         # Plotting SPL
@@ -1945,7 +1976,10 @@ class Spectrogram(Dataset):
         p = np.nanpercentile(all_welch, percen, 0, interpolation="linear")
         for i in range(len(p)):
             plt.plot(
-                Freq, p[i, :], linewidth=2, label="%s %% percentil" % percen[i],
+                Freq,
+                p[i, :],
+                linewidth=2,
+                label="%s %% percentil" % percen[i],
             )
 
         ax.semilogx()

--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -1964,7 +1964,7 @@ class Spectrogram(Dataset):
             plt.savefig(output_file, bbox_inches="tight", pad_inches=0)
             plt.close()
 
-            output_file_npz = self.path / OSMOSE_PATH.EPD / f"EPD.npz"
+            output_file_npz = self.path / OSMOSE_PATH.EPD / "EPD.npz"
 
             np.savez(
                 output_file_npz,

--- a/src/OSmOSE/Weather.py
+++ b/src/OSmOSE/Weather.py
@@ -7,7 +7,7 @@ Created on Wed Oct  4 16:06:18 2023
 """
 from pathlib import Path
 import os
-from OSmOSE.config import *
+from OSmOSE.config import OSMOSE_PATH, DPDEFAULT
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
@@ -131,7 +131,7 @@ class Weather:
             y_train = y_train[x_train < val_outlier]
             x_train = x_train[x_train < val_outlier]
         if threshold_SPL:
-            if type(threshold_SPL) == int:
+            if type(threshold_SPL) is int:
                 y_train = y_train[x_train < threshold_SPL]
                 x_train = x_train[x_train < threshold_SPL]
             else:

--- a/src/OSmOSE/Weather.py
+++ b/src/OSmOSE/Weather.py
@@ -89,7 +89,7 @@ class Weather:
             )  # careful data not sorted here! we should save them based on dataframe df below
 
         else:
-            print(f"Your complete welch npz is already built! move on..")
+            print("Your complete welch npz is already built! move on..")
 
     def wind_speed_estimation(
         self,
@@ -334,7 +334,7 @@ class Weather:
 class benchmark_weather:
     def __init__(self, osmose_path_dataset, dataset, local=True):
         if not isinstance(dataset, list):
-            print(f"Dataset should be multiple and defined within a list")
+            print("Dataset should be multiple and defined within a list")
             sys.exit(0)
 
         self.path = Path(osmose_path_dataset)

--- a/src/OSmOSE/Weather.py
+++ b/src/OSmOSE/Weather.py
@@ -85,7 +85,11 @@ class Weather:
                 ]  # suprinsingly , doing simply = list(time) was droping the Timestamp dtype, to be investigated in more depth...
 
             np.savez(
-                path_all_welch, LTAS=LTAS, time=time, Freq=Freq, allow_pickle=True,
+                path_all_welch,
+                LTAS=LTAS,
+                time=time,
+                Freq=Freq,
+                allow_pickle=True,
             )  # careful data not sorted here! we should save them based on dataframe df below
 
         else:
@@ -182,7 +186,8 @@ class Weather:
         )
 
         with open(
-            self.path.joinpath(OSMOSE_PATH.weather, "polynomial_law.txt"), "w",
+            self.path.joinpath(OSMOSE_PATH.weather, "polynomial_law.txt"),
+            "w",
         ) as f:
             for item in z:
                 f.write("%s\n" % item)

--- a/src/OSmOSE/Weather.py
+++ b/src/OSmOSE/Weather.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Wed Oct  4 16:06:18 2023
+"""Created on Wed Oct  4 16:06:18 2023
 
 @author: cazaudo
 """
-from pathlib import Path
-import os
-from OSmOSE.config import OSMOSE_PATH, DPDEFAULT
-import pandas as pd
-import numpy as np
-import matplotlib.pyplot as plt
-from OSmOSE.utils import make_path
-from tqdm import tqdm
-import sys
 import itertools
+import os
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
+from OSmOSE.config import DPDEFAULT, OSMOSE_PATH
+from OSmOSE.utils import make_path
 
 
 class Weather:
@@ -85,7 +85,7 @@ class Weather:
                 ]  # suprinsingly , doing simply = list(time) was droping the Timestamp dtype, to be investigated in more depth...
 
             np.savez(
-                path_all_welch, LTAS=LTAS, time=time, Freq=Freq, allow_pickle=True
+                path_all_welch, LTAS=LTAS, time=time, Freq=Freq, allow_pickle=True,
             )  # careful data not sorted here! we should save them based on dataframe df below
 
         else:
@@ -113,7 +113,7 @@ class Weather:
             {
                 "SPL_filtered": df["SPL_filtered"],
                 "InSituWIND": np.sqrt(df["interp_u10"] ** 2 + df["interp_v10"] ** 2),
-            }
+            },
         )
 
         feature_matrix = feature_matrix[pd.notnull(feature_matrix["InSituWIND"])]
@@ -178,11 +178,11 @@ class Weather:
         else:
             plt.close()
         print(
-            f"Saving figure {self.path.joinpath(OSMOSE_PATH.weather,'scatter_wind_model.png')}"
+            f"Saving figure {self.path.joinpath(OSMOSE_PATH.weather,'scatter_wind_model.png')}",
         )
 
         with open(
-            self.path.joinpath(OSMOSE_PATH.weather, "polynomial_law.txt"), "w"
+            self.path.joinpath(OSMOSE_PATH.weather, "polynomial_law.txt"), "w",
         ) as f:
             for item in z:
                 f.write("%s\n" % item)
@@ -236,7 +236,7 @@ class Weather:
         else:
             plt.close()
         print(
-            f"Saving figure {self.path.joinpath(OSMOSE_PATH.weather,'scatter_ecmwf_model.png')}"
+            f"Saving figure {self.path.joinpath(OSMOSE_PATH.weather,'scatter_ecmwf_model.png')}",
         )
 
         # temporal_ecmwf_model
@@ -273,7 +273,7 @@ class Weather:
         else:
             plt.close()
         print(
-            f"Saving figure {self.path.joinpath(OSMOSE_PATH.weather,'temporal_ecmwf_model.png')}"
+            f"Saving figure {self.path.joinpath(OSMOSE_PATH.weather,'temporal_ecmwf_model.png')}",
         )
 
     def append_SPL_filtered(self, freq_min: int, freq_max: int):
@@ -305,13 +305,13 @@ class Weather:
                     ltas["Sxx"][
                         0,
                         np.argmin(abs(ltas["Freq"] - freq_min)) : np.argmax(
-                            abs(ltas["Freq"] - freq_max)
+                            abs(ltas["Freq"] - freq_max),
                         ),
-                    ]
+                    ],
                 )
             else:
                 pre_SPL = np.mean(
-                    ltas["Sxx"][0, np.argmin(abs(ltas["Freq"] - freq_min))]
+                    ltas["Sxx"][0, np.argmin(abs(ltas["Freq"] - freq_min))],
                 )
 
             if metadata_spectrogram["spectro_normalization"][0] == "density":
@@ -366,7 +366,7 @@ class benchmark_weather:
         ct = 0
         for dd in self.dataset:
             f = open(
-                self.path.joinpath(dd, OSMOSE_PATH.weather, "polynomial_law.txt"), "r"
+                self.path.joinpath(dd, OSMOSE_PATH.weather, "polynomial_law.txt"),
             )
             xx = f.read()
             ll = [float(x) for x in xx.split("\n")[:-1]]
@@ -377,9 +377,9 @@ class benchmark_weather:
                 "-",
                 dd,
                 " : ",
-                "{:.3f}".format(p[0]),
-                "/ {:.3f}".format(p[1]),
-                "/ {:.3f}".format(p[2]),
+                f"{p[0]:.3f}",
+                f"/ {p[1]:.3f}",
+                f"/ {p[2]:.3f}",
             )
 
             x = np.arange(-20, 0, 0.1)

--- a/src/OSmOSE/__init__.py
+++ b/src/OSmOSE/__init__.py
@@ -1,8 +1,8 @@
+from OSmOSE import utils
+from OSmOSE.Auxiliary import Auxiliary
 from OSmOSE.Dataset import Dataset
 from OSmOSE.job import Job_builder
 from OSmOSE.Spectrogram import Spectrogram
-import OSmOSE.utils as utils
-from OSmOSE.Auxiliary import Auxiliary
 
 __all__ = [
     "Auxiliary",

--- a/src/OSmOSE/cluster/audio_reshaper.py
+++ b/src/OSmOSE/cluster/audio_reshaper.py
@@ -1,14 +1,16 @@
-import pandas as pd
 from argparse import ArgumentParser
 from pathlib import Path
+
 import numpy as np
+import pandas as pd
 import soundfile as sf
 from librosa import resample
+
 from OSmOSE.config import DPDEFAULT, FPDEFAULT
-from OSmOSE.utils.timestamp_utils import to_timestamp
 from OSmOSE.utils.audio_utils import get_all_audio_files
-from OSmOSE.utils.core_utils import set_umask, chmod_if_needed
+from OSmOSE.utils.core_utils import chmod_if_needed, set_umask
 from OSmOSE.utils.path_utils import make_path
+from OSmOSE.utils.timestamp_utils import to_timestamp
 
 
 def reshape(
@@ -30,8 +32,7 @@ def reshape(
     overwrite: bool = True,
     threshold: int = 5,
 ):
-    """
-    Reshape all audio files in the folder to be of the specified duration and/or sampling rate.
+    """Reshape all audio files in the folder to be of the specified duration and/or sampling rate.
 
     Parameters
     ----------
@@ -88,6 +89,7 @@ def reshape(
 
     threshold : int, optional
         Integer from 0 to 100 to filter out segments with a number of sample inferior to (threshold * spectrogram duration * new_sr)
+
     """
     set_umask()
     segment_duration = pd.Timedelta(seconds=segment_size)
@@ -96,7 +98,7 @@ def reshape(
     # validation for threshold
     if not (0 <= threshold <= 100):
         raise ValueError(
-            "The 'threshold' parameter must be an integer between 0 and 100."
+            "The 'threshold' parameter must be an integer between 0 and 100.",
         )
 
     # validation datetimes
@@ -124,14 +126,14 @@ def reshape(
 
     if not input_dir_path.exists():
         raise ValueError(
-            f"The input files must be a valid folder path, not '{input_dir_path}'."
+            f"The input files must be a valid folder path, not '{input_dir_path}'.",
         )
 
     if not (input_dir_path / "timestamp.csv").exists() and (
         not timestamp_path or not timestamp_path.exists()
     ):
         raise FileNotFoundError(
-            f"The timestamp.csv file must be present in the directory {Path(input_dir_path)} and correspond to the audio files in the same location, or be specified in the argument."
+            f"The timestamp.csv file must be present in the directory {Path(input_dir_path)} and correspond to the audio files in the same location, or be specified in the argument.",
         )
 
     # output directory
@@ -139,7 +141,7 @@ def reshape(
         output_dir_path = input_dir_path
         if overwrite:
             raise ValueError(
-                "Cannot overwrite input directory when the output directory is implicit!"
+                "Cannot overwrite input directory when the output directory is implicit!",
             )
     if not output_dir_path.exists():
         make_path(output_dir_path, mode=DPDEFAULT)
@@ -148,14 +150,14 @@ def reshape(
     input_timestamp = pd.read_csv(
         timestamp_path
         if timestamp_path and timestamp_path.exists()
-        else input_dir_path / "timestamp.csv"
+        else input_dir_path / "timestamp.csv",
     )
 
     if file_metadata_path and file_metadata_path.exists():
         file_metadata = pd.read_csv(file_metadata_path, parse_dates=["timestamp"])
     else:
         file_metadata = pd.read_csv(
-            input_dir_path / "file_metadata.csv", parse_dates=["timestamp"]
+            input_dir_path / "file_metadata.csv", parse_dates=["timestamp"],
         )
 
     filenames = [file.name for file in files]
@@ -169,7 +171,7 @@ def reshape(
 
     if not datetime_end:
         datetime_end = file_metadata["timestamp"].iloc[-1] + pd.Timedelta(
-            file_metadata["duration"].iloc[-1], unit="s"
+            file_metadata["duration"].iloc[-1], unit="s",
         )
 
     # segment timestamps
@@ -188,7 +190,7 @@ def reshape(
         for i, ts in enumerate(origin_timestamp["timestamp"]):
             current_ts = ts
             original_timedelta = pd.Timedelta(
-                seconds=origin_timestamp["duration"].iloc[i]
+                seconds=origin_timestamp["duration"].iloc[i],
             )
 
             while current_ts <= ts + original_timedelta:
@@ -213,7 +215,7 @@ def reshape(
                 (i + batch_ind_min) * segment_duration
             )
             segment_datetime_end = min(
-                segment_datetime_begin + segment_duration, datetime_end
+                segment_datetime_begin + segment_duration, datetime_end,
             )
         else:
             segment_datetime_begin = new_file[i + batch_ind_min]
@@ -242,7 +244,7 @@ def reshape(
                         0.0,
                         (segment_datetime_begin - file_datetime_begin).total_seconds(),
                     )
-                    * orig_sr
+                    * orig_sr,
                 )
 
                 end_offset = int(
@@ -250,7 +252,7 @@ def reshape(
                         (segment_datetime_end - file_datetime_begin),
                         (file_datetime_end - file_datetime_begin),
                     ).total_seconds()
-                    * orig_sr
+                    * orig_sr,
                 )
 
                 # read the appropriate section of the origin audio file
@@ -332,7 +334,6 @@ def reshape(
     if verbose:
         print(msg_log)
 
-    return
 
 
 if __name__ == "__main__":

--- a/src/OSmOSE/cluster/audio_reshaper.py
+++ b/src/OSmOSE/cluster/audio_reshaper.py
@@ -1,4 +1,3 @@
-import os
 import pandas as pd
 from argparse import ArgumentParser
 from pathlib import Path

--- a/src/OSmOSE/cluster/audio_reshaper.py
+++ b/src/OSmOSE/cluster/audio_reshaper.py
@@ -148,16 +148,19 @@ def reshape(
 
     # load timestamp and metadata
     input_timestamp = pd.read_csv(
-        timestamp_path
-        if timestamp_path and timestamp_path.exists()
-        else input_dir_path / "timestamp.csv",
+        (
+            timestamp_path
+            if timestamp_path and timestamp_path.exists()
+            else input_dir_path / "timestamp.csv"
+        ),
     )
 
     if file_metadata_path and file_metadata_path.exists():
         file_metadata = pd.read_csv(file_metadata_path, parse_dates=["timestamp"])
     else:
         file_metadata = pd.read_csv(
-            input_dir_path / "file_metadata.csv", parse_dates=["timestamp"],
+            input_dir_path / "file_metadata.csv",
+            parse_dates=["timestamp"],
         )
 
     filenames = [file.name for file in files]
@@ -171,7 +174,8 @@ def reshape(
 
     if not datetime_end:
         datetime_end = file_metadata["timestamp"].iloc[-1] + pd.Timedelta(
-            file_metadata["duration"].iloc[-1], unit="s",
+            file_metadata["duration"].iloc[-1],
+            unit="s",
         )
 
     # segment timestamps
@@ -215,7 +219,8 @@ def reshape(
                 (i + batch_ind_min) * segment_duration
             )
             segment_datetime_end = min(
-                segment_datetime_begin + segment_duration, datetime_end,
+                segment_datetime_begin + segment_duration,
+                datetime_end,
             )
         else:
             segment_datetime_begin = new_file[i + batch_ind_min]
@@ -333,7 +338,6 @@ def reshape(
 
     if verbose:
         print(msg_log)
-
 
 
 if __name__ == "__main__":

--- a/src/OSmOSE/cluster/audio_reshaper.py
+++ b/src/OSmOSE/cluster/audio_reshaper.py
@@ -4,16 +4,11 @@ from pathlib import Path
 import numpy as np
 import soundfile as sf
 from librosa import resample
-
-from OSmOSE.utils import (
-    DPDEFAULT,
-    FPDEFAULT,
-    to_timestamp,
-    get_all_audio_files,
-    set_umask,
-    make_path,
-    chmod_if_needed,
-)
+from OSmOSE.config import DPDEFAULT, FPDEFAULT
+from OSmOSE.utils.timestamp_utils import to_timestamp
+from OSmOSE.utils.audio_utils import get_all_audio_files
+from OSmOSE.utils.core_utils import set_umask, chmod_if_needed
+from OSmOSE.utils.path_utils import make_path
 
 
 def reshape(

--- a/src/OSmOSE/cluster/compute_statistics.py
+++ b/src/OSmOSE/cluster/compute_statistics.py
@@ -3,7 +3,6 @@ import sys
 import csv
 import argparse
 
-import pandas as pd
 
 import soundfile as sf
 import numpy as np

--- a/src/OSmOSE/cluster/compute_statistics.py
+++ b/src/OSmOSE/cluster/compute_statistics.py
@@ -1,14 +1,13 @@
-from pathlib import Path
-import sys
-import csv
 import argparse
+import csv
+import sys
+from pathlib import Path
 
-
-import soundfile as sf
 import numpy as np
+import soundfile as sf
 from scipy import signal
 
-from OSmOSE.utils.core_utils import set_umask, get_timestamp_of_audio_file
+from OSmOSE.utils.core_utils import get_timestamp_of_audio_file, set_umask
 
 
 def Write_zscore_norma_params(
@@ -41,6 +40,7 @@ def Write_zscore_norma_params(
 
     batch_ind_max: `int`
         The last file of the list to be processed. Default is -1, meaning the entire list is processed.
+
     """
     set_umask()
 
@@ -60,7 +60,7 @@ def Write_zscore_norma_params(
         bpcoef = signal.butter(
             20,
             np.array(
-                [max(hp_filter_min_freq, sys.float_info.epsilon), sample_rate / 2 - 1]
+                [max(hp_filter_min_freq, sys.float_info.epsilon), sample_rate / 2 - 1],
             ),
             fs=sample_rate,
             output="sos",
@@ -69,11 +69,11 @@ def Write_zscore_norma_params(
         data = signal.sosfilt(bpcoef, data)
 
         current_timestamp = get_timestamp_of_audio_file(
-            Path(input_dir).joinpath("timestamp.csv"), wav.name
+            Path(input_dir).joinpath("timestamp.csv"), wav.name,
         )
 
         list_summaryStats.append(
-            [wav.name, current_timestamp, np.mean(data), np.std(data)]
+            [wav.name, current_timestamp, np.mean(data), np.std(data)],
         )
 
     with open(output_file, "w", newline="") as f:
@@ -86,7 +86,7 @@ def Write_zscore_norma_params(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Python script to get the mean and standard deviation of audio files, used in zscore parameter calculation."
+        description="Python script to get the mean and standard deviation of audio files, used in zscore parameter calculation.",
     )
     required = parser.add_argument_group("required arguments")
     required.add_argument(

--- a/src/OSmOSE/cluster/compute_statistics.py
+++ b/src/OSmOSE/cluster/compute_statistics.py
@@ -69,7 +69,8 @@ def Write_zscore_norma_params(
         data = signal.sosfilt(bpcoef, data)
 
         current_timestamp = get_timestamp_of_audio_file(
-            Path(input_dir).joinpath("timestamp.csv"), wav.name,
+            Path(input_dir).joinpath("timestamp.csv"),
+            wav.name,
         )
 
         list_summaryStats.append(

--- a/src/OSmOSE/cluster/merge_timestamp_csv.py
+++ b/src/OSmOSE/cluster/merge_timestamp_csv.py
@@ -8,8 +8,6 @@ import os
 def merge_timestamp_csv(input_files: str):
     input_dir_path = Path(input_files)
 
-    list_audio = list(input_dir_path.glob("timestamp_*"))
-
     list_conca_timestamps = []
     list_conca_filename = []
     for ll in list(input_dir_path.glob("timestamp_*")):

--- a/src/OSmOSE/cluster/merge_timestamp_csv.py
+++ b/src/OSmOSE/cluster/merge_timestamp_csv.py
@@ -1,8 +1,9 @@
-from pathlib import Path
-import pandas as pd
 import itertools
-from argparse import ArgumentParser
 import os
+from argparse import ArgumentParser
+from pathlib import Path
+
+import pandas as pd
 
 
 def merge_timestamp_csv(input_files: str):
@@ -16,12 +17,12 @@ def merge_timestamp_csv(input_files: str):
         list_conca_filename.append(list(pd.read_csv(ll)["filename"].values))
         os.remove(ll)
 
-    print(f"save file {str(input_dir_path.joinpath('timestamp.csv'))}")
+    print(f"save file {input_dir_path.joinpath('timestamp.csv')!s}")
     df = pd.DataFrame(
         {
             "filename": list(itertools.chain(*list_conca_filename)),
             "timestamp": list(itertools.chain(*list_conca_timestamps)),
-        }
+        },
     )
     df.sort_values(by=["timestamp"], inplace=True)
     df.to_csv(input_dir_path.joinpath("timestamp.csv"), index=False)

--- a/src/OSmOSE/cluster/resample.py
+++ b/src/OSmOSE/cluster/resample.py
@@ -1,9 +1,10 @@
 import argparse
-from pathlib import Path
-import subprocess
 import platform
-from OSmOSE.utils.core_utils import set_umask
+import subprocess
+from pathlib import Path
+
 from OSmOSE.utils.audio_utils import get_all_audio_files
+from OSmOSE.utils.core_utils import set_umask
 
 
 def resample(
@@ -28,8 +29,8 @@ def resample(
             The index of the first file of the batch. The default is 0.
         batch_ind_max: `int`, keyword-only
             The index of the last file of the batch. The default is -1, meaning the last file of the input directory.
-    """
 
+    """
     set_umask()
     if platform.system() == "Windows":
         print("Sox is unavailable on Windows")
@@ -46,8 +47,8 @@ def resample(
 
     for audio_file in audio_files_list:
         subprocess.run(
-            f"sox {str(audio_file)} -r {str(target_sr)} -t wavpcm {str(Path(output_dir, audio_file.name))}",
-            shell=True,
+            f"sox {audio_file!s} -r {target_sr!s} -t wavpcm {Path(output_dir, audio_file.name)!s}",
+            shell=True, check=False,
         )
 
         print(f"{audio_file.name} resampled to {target_sr}!")
@@ -59,7 +60,7 @@ def resample(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Python script to resample a list of audio files using the sox tool. Does not change the file duration."
+        description="Python script to resample a list of audio files using the sox tool. Does not change the file duration.",
     )
     required = parser.add_argument_group("required arguments")
     required.add_argument(
@@ -75,7 +76,7 @@ if __name__ == "__main__":
         help="The output folder of the resampled files.",
     )
     required.add_argument(
-        "--target-sr", "-sr", required=True, type=int, help="The target samplerate."
+        "--target-sr", "-sr", required=True, type=int, help="The target samplerate.",
     )
     parser.add_argument(
         "--batch-ind-min",

--- a/src/OSmOSE/cluster/resample.py
+++ b/src/OSmOSE/cluster/resample.py
@@ -48,7 +48,8 @@ def resample(
     for audio_file in audio_files_list:
         subprocess.run(
             f"sox {audio_file!s} -r {target_sr!s} -t wavpcm {Path(output_dir, audio_file.name)!s}",
-            shell=True, check=False,
+            shell=True,
+            check=False,
         )
 
         print(f"{audio_file.name} resampled to {target_sr}!")
@@ -76,7 +77,11 @@ if __name__ == "__main__":
         help="The output folder of the resampled files.",
     )
     required.add_argument(
-        "--target-sr", "-sr", required=True, type=int, help="The target samplerate.",
+        "--target-sr",
+        "-sr",
+        required=True,
+        type=int,
+        help="The target samplerate.",
     )
     parser.add_argument(
         "--batch-ind-min",

--- a/src/OSmOSE/cluster/resample.py
+++ b/src/OSmOSE/cluster/resample.py
@@ -4,7 +4,6 @@ import subprocess
 import platform
 from OSmOSE.utils.core_utils import set_umask
 from OSmOSE.utils.audio_utils import get_all_audio_files
-from OSmOSE.config import *
 
 
 def resample(

--- a/src/OSmOSE/config.py
+++ b/src/OSmOSE/config.py
@@ -1,6 +1,6 @@
-from pathlib import Path
-from collections import namedtuple
 import stat
+from collections import namedtuple
+from pathlib import Path
 
 SUPPORTED_AUDIO_FORMAT = [".wav", ".flac"]
 

--- a/src/OSmOSE/frequency_scales/abstract_frequency_scale.py
+++ b/src/OSmOSE/frequency_scales/abstract_frequency_scale.py
@@ -1,5 +1,4 @@
 import abc
-import numpy as np
 from dataclasses import dataclass
 
 

--- a/src/OSmOSE/frequency_scales/custom_frequency_scale.py
+++ b/src/OSmOSE/frequency_scales/custom_frequency_scale.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
-from OSmOSE.frequency_scales.abstract_frequency_scale import AbstractFrequencyScale
 from typing import Tuple
+
+from OSmOSE.frequency_scales.abstract_frequency_scale import AbstractFrequencyScale
 
 
 @dataclass
@@ -37,25 +38,23 @@ class CustomFrequencyScale(AbstractFrequencyScale):
         c1, c2, c3 = self.coefficients
         if freq <= f1:
             return freq / f1 * c1
-        elif freq <= f2:
+        if freq <= f2:
             return c1 + (freq - f1) / (f2 - f1) * c2 if f1 != f2 else c1
-        else:
-            return (
-                c1 + c2 + (freq - f2) / (0.5 * self.sr - f2) * c3
-                if (f2 != 0.5 * self.sr or c3 == 0)
-                else c1 + c2
-            )
+        return (
+            c1 + c2 + (freq - f2) / (0.5 * self.sr - f2) * c3
+            if (f2 != 0.5 * self.sr or c3 == 0)
+            else c1 + c2
+        )
 
     def map_scale2freq(self, custom_freq):
         f1, f2 = self.frequencies
         c1, c2, c3 = self.coefficients
         if custom_freq <= c1:
             return custom_freq / c1 * f1
-        elif custom_freq <= c1 + c2:
+        if custom_freq <= c1 + c2:
             return f1 + (custom_freq - c1) / c2 * (f2 - f1) if c2 != 0 else f1
-        else:
-            return (
-                f2 + (custom_freq - c1 - c2) / c3 * (0.5 * self.sr - f2)
-                if c3 != 0
-                else 0.5 * self.sr
-            )
+        return (
+            f2 + (custom_freq - c1 - c2) / c3 * (0.5 * self.sr - f2)
+            if c3 != 0
+            else 0.5 * self.sr
+        )

--- a/src/OSmOSE/frequency_scales/frequency_scale_serializer.py
+++ b/src/OSmOSE/frequency_scales/frequency_scale_serializer.py
@@ -27,10 +27,9 @@ class FrequencyScaleSerializer:
         if config_name in self.configurations:
             scale_class, kwargs = self.configurations[config_name]
             print(
-                f"The y-scale used for spectrogram generation is {config_name} with sampling rate {sr}"
+                f"The y-scale used for spectrogram generation is {config_name} with sampling rate {sr}",
             )
             return scale_class(sr=sr, **kwargs)
-        else:
-            raise ValueError(
-                f"No configuration found for {config_name}, accepted values are {self.configurations.keys()}"
-            )
+        raise ValueError(
+            f"No configuration found for {config_name}, accepted values are {self.configurations.keys()}",
+        )

--- a/src/OSmOSE/func_api.py
+++ b/src/OSmOSE/func_api.py
@@ -115,7 +115,16 @@ def save_results(dates, lat, lon, single_levels, variables, filename):
 
 
 def final_creation(
-    df1, filename, key, variable, year, month, day, time, area, type_crea="complexe",
+    df1,
+    filename,
+    key,
+    variable,
+    year,
+    month,
+    day,
+    time,
+    area,
+    type_crea="complexe",
 ):
     return_cdsapi(filename, key, variable, year, month, day, time, area)
     dates, lon, lat, single_levels, variables = format_nc(filename)

--- a/src/OSmOSE/func_api.py
+++ b/src/OSmOSE/func_api.py
@@ -1,9 +1,10 @@
-import cdsapi
-from datetime import date, datetime
 import os
-from netCDF4 import Dataset
+from datetime import date, datetime
+
+import cdsapi
 import numpy as np
 import pandas as pd
+from netCDF4 import Dataset
 
 
 def make_cds_file(key, udi, path_to_api):
@@ -14,7 +15,7 @@ def make_cds_file(key, udi, path_to_api):
         pass
 
     cmd1 = "echo url: https://cds.climate.copernicus.eu/api/v2 >> .cdsapirc"
-    cmd2 = "echo key: {}:{} >> .cdsapirc".format(udi, key)
+    cmd2 = f"echo key: {udi}:{key} >> .cdsapirc"
     os.system(cmd1)
     os.system(cmd2)
 
@@ -66,7 +67,7 @@ def format_nc(filename):
             fh.dimensions.get("time").size,
             fh.dimensions.get("latitude").size,
             fh.dimensions.get("longitude").size,
-        )
+        ),
     )
 
     lon = fh.variables["longitude"][:]
@@ -89,7 +90,7 @@ def format_nc(filename):
         [
             datetime(elem.year, elem.month, elem.day, hour)
             for elem, hour in list(zip(data["time"], hours))
-        ]
+        ],
     )
 
     print("\n[======>-----]\n")
@@ -111,11 +112,10 @@ def save_results(dates, lat, lon, single_levels, variables, filename):
                 stamps[i, j, k] = [dates[i], lat[j], lon[k]]
     np.save("stamps_" + filename, stamps, allow_pickle=True)
     print("\n[============]\nDone")
-    return None
 
 
 def final_creation(
-    df1, filename, key, variable, year, month, day, time, area, type_crea="complexe"
+    df1, filename, key, variable, year, month, day, time, area, type_crea="complexe",
 ):
     return_cdsapi(filename, key, variable, year, month, day, time, area)
     dates, lon, lat, single_levels, variables = format_nc(filename)
@@ -140,7 +140,7 @@ def mise_en_forme_old(filename):
             fh.dimensions.get("longitude").size,
             fh.dimensions.get("longitude").size,
             fh.dimensions.get("longitude").size,
-        )
+        ),
     )
 
     lons = fh.variables["longitude"][:]
@@ -229,7 +229,7 @@ def creation_complexe_old(df1, df2, u10, v10, tp, lats, lons):
             "u10": u10_,
             "v10": v10_,
             "tp": tp_,
-        }
+        },
     )
     print("\n[============]\n")
     return data_fin
@@ -242,8 +242,8 @@ def prepare_coord_target_old(filename):
     # test_.columns = ['time', 'long', 'lat', 'profondeur']
     test_["time"] = test_["time"].apply(
         lambda x: pd.Timestamp(
-            datetime.utcfromtimestamp(x).strftime("%Y-%m-%d %H:%M:%S")
-        )
+            datetime.utcfromtimestamp(x).strftime("%Y-%m-%d %H:%M:%S"),
+        ),
     )
 
     test_["year"] = test_["time"]

--- a/src/OSmOSE/func_api.py
+++ b/src/OSmOSE/func_api.py
@@ -23,7 +23,7 @@ def make_cds_file(key, udi, path_to_api):
     except FileExistsError:
         pass
 
-    if path_to_api == None:
+    if path_to_api is None:
         path_to_api = os.path.join(os.path.expanduser("~"), "Documents/api/")
 
     os.chdir(path_to_api)
@@ -75,8 +75,6 @@ def format_nc(filename):
     for i in range(len(variables)):
         single_levels[i] = fh.variables[variables[i]][:]
 
-    time_units = fh.variables["time"].units
-
     def transf_temps(time):
         time_str = float(time) / 24 + date.toordinal(date(1900, 1, 1))
         return date.fromordinal(int(time_str))
@@ -121,7 +119,7 @@ def final_creation(
 ):
     return_cdsapi(filename, key, variable, year, month, day, time, area)
     dates, lon, lat, single_levels, variables = format_nc(filename)
-    test = save_results(dates, lat, lon, single_levels, variables, filename)
+    save_results(dates, lat, lon, single_levels, variables, filename)
     return variables
 
 
@@ -151,8 +149,6 @@ def mise_en_forme_old(filename):
     for i in range(len(variables)):
         single_levels[i] = fh.variables[variables[i]][:]
 
-    time_units = fh.variables["time"].units
-
     def transf_temps(time):
         time_str = float(time) / 24 + date.toordinal(date(1900, 1, 1))
         return date.fromordinal(int(time_str))
@@ -174,7 +170,7 @@ def mise_en_forme_old(filename):
 
     print("\n[======>-----]\n")
 
-    return data, lons, lats, u10, v10, tp
+    return data, lons, lats
 
 
 # df_spams_fin : df1, data : df2

--- a/src/OSmOSE/job.py
+++ b/src/OSmOSE/job.py
@@ -425,7 +425,9 @@ class Job_builder:
 
     # TODO support multiple dependencies and job chaining (?)
     def submit_job(
-        self, jobfile: str = None, dependency: str | List[str] = None,
+        self,
+        jobfile: str = None,
+        dependency: str | List[str] = None,
     ) -> List[str]:
         """Submits the job file to the cluster using the job scheduler written in the file name or in the configuration file.
 
@@ -472,7 +474,9 @@ class Job_builder:
                 dep = f"-d afterok:{dependency}" if dependency else ""
                 jobid = (
                     subprocess.run(
-                        ["sbatch", dep, jobinfo["path"]], stdout=subprocess.PIPE, check=False,
+                        ["sbatch", dep, jobinfo["path"]],
+                        stdout=subprocess.PIPE,
+                        check=False,
                     )
                     .stdout.decode("utf-8")
                     .rstrip("\n")
@@ -514,7 +518,8 @@ class Job_builder:
             res += "==== PREPARED JOBS ====\n\n"
         for job_info in self.prepared_jobs:
             created_at = datetime.strptime(
-                today + job_info["outfile"].stem[-11:-3], "%d%m%y%H-%M-%S",
+                today + job_info["outfile"].stem[-11:-3],
+                "%d%m%y%H-%M-%S",
             )
             res += (
                 f"{job_info['job_name']} (created at {created_at}) : ready to start.\n"
@@ -524,7 +529,8 @@ class Job_builder:
             res += "==== ONGOING JOBS ====\n\n"
         for job_info in self.ongoing_jobs:
             created_at = datetime.strptime(
-                today + job_info["outfile"].stem[-11:-3], "%d%m%y%H-%M-%S",
+                today + job_info["outfile"].stem[-11:-3],
+                "%d%m%y%H-%M-%S",
             )
             delta = datetime.now() - created_at
             strftime = f"{'%H hours, ' if delta.seconds >= 3600 else ''}{'%M minutes and ' if delta.seconds >= 60 else ''}%S seconds"
@@ -535,7 +541,8 @@ class Job_builder:
             res += "==== FINISHED JOBS ====\n\n"
         for job_info in self.finished_jobs:
             created_at = datetime.strptime(
-                today + job_info["outfile"].stem[-11:-3], "%d%m%y%H-%M-%S",
+                today + job_info["outfile"].stem[-11:-3],
+                "%d%m%y%H-%M-%S",
             )
 
             if not job_info["outfile"].exists():
@@ -543,7 +550,9 @@ class Job_builder:
             else:
                 delta = (
                     datetime.fromtimestamp(
-                        time.mktime(time.localtime(job_info["outfile"].stat().st_ctime)),
+                        time.mktime(
+                            time.localtime(job_info["outfile"].stat().st_ctime)
+                        ),
                     )
                     - created_at
                 )
@@ -583,7 +592,9 @@ class Job_builder:
             job_id = 0
             if job_name:
                 job_id = get_dict_index_in_list(
-                    self.finished_jobs, "job_name", job_name.rstrip(),
+                    self.finished_jobs,
+                    "job_name",
+                    job_name.rstrip(),
                 )
             elif len(self.finished_jobs) == 0:
                 print(
@@ -603,11 +614,15 @@ class Job_builder:
     def delete_job(self, job_identifier: str):
         try:
             job_id = get_dict_index_in_list(
-                self.ongoing_jobs, "job_name", job_identifier.rstrip(),
+                self.ongoing_jobs,
+                "job_name",
+                job_identifier.rstrip(),
             )
         except ValueError:
             job_id = get_dict_index_in_list(
-                self.ongoing_jobs, "id", job_identifier.rstrip(),
+                self.ongoing_jobs,
+                "id",
+                job_identifier.rstrip(),
             )
 
         jobinfo = self.ongoing_jobs[job_id]

--- a/src/OSmOSE/job.py
+++ b/src/OSmOSE/job.py
@@ -5,7 +5,6 @@ import json
 import time
 import tomlkit
 import subprocess
-from uuid import uuid4
 from string import Template
 from typing import NamedTuple, List, Literal
 from warnings import warn
@@ -13,7 +12,8 @@ from pathlib import Path
 from datetime import datetime
 from importlib import resources
 from OSmOSE.utils.core_utils import read_config, set_umask, chmod_if_needed
-from OSmOSE.config import *
+from OSmOSE.config import DPDEFAULT, FPDEFAULT
+from collections import namedtuple
 
 JOB_CONFIG_TEMPLATE = namedtuple(
     "job_config",
@@ -286,8 +286,6 @@ class Job_builder:
         else:
             preset = None
 
-        pwd = Path(__file__).parent
-
         logdir.mkdir(mode=DPDEFAULT, exist_ok=True)
 
         job_file = ["#!/bin/bash"]
@@ -450,9 +448,7 @@ class Job_builder:
 
         if isinstance(dependency, list):
             dependency = ":".join(dependency)
-
-        jobarray_uuid = str(uuid4())
-        job_dir = Path(jobinfo_list[0]["path"]).parent
+            
         # TODO: Think about the issue when a job have too many dependencies and workaround.
 
         for i, jobinfo in enumerate(jobinfo_list):

--- a/src/OSmOSE/job.py
+++ b/src/OSmOSE/job.py
@@ -1,19 +1,21 @@
-from copy import copy
 import glob
-import os
 import json
-import time
-import tomlkit
+import os
 import subprocess
-from string import Template
-from typing import NamedTuple, List, Literal
-from warnings import warn
-from pathlib import Path
+import time
+from collections import namedtuple
+from copy import copy
 from datetime import datetime
 from importlib import resources
-from OSmOSE.utils.core_utils import read_config, set_umask, chmod_if_needed
+from pathlib import Path
+from string import Template
+from typing import List, Literal, NamedTuple
+from warnings import warn
+
+import tomlkit
+
 from OSmOSE.config import DPDEFAULT, FPDEFAULT
-from collections import namedtuple
+from OSmOSE.utils.core_utils import chmod_if_needed, read_config, set_umask
 
 JOB_CONFIG_TEMPLATE = namedtuple(
     "job_config",
@@ -37,7 +39,7 @@ class Job_builder:
         if config_file is None:
             self.__configfile = "config.toml"
             self.__full_config: NamedTuple = read_config(
-                resources.files("OSmOSE").joinpath(self.__configfile)
+                resources.files("OSmOSE").joinpath(self.__configfile),
             )
 
         else:
@@ -66,7 +68,7 @@ class Job_builder:
 
         if not all(prop in self.__config.keys() for prop in required_properties):
             raise ValueError(
-                f"The provided configuration file is missing the following attributes: {'; '.join(list(set(required_properties).difference(set(self.__config._fields))))}"
+                f"The provided configuration file is missing the following attributes: {'; '.join(list(set(required_properties).difference(set(self.__config._fields))))}",
             )
 
     # region Properties
@@ -193,7 +195,6 @@ class Job_builder:
         ---------
             `output_file`: the path to the new configuration file (in TOML or JSON format).
         """
-
         output_format = (
             Path(output_file).suffix if output_file else Path(self.__configfile).suffix
         )
@@ -274,12 +275,13 @@ class Job_builder:
         -------
         job_path : `str`
             The path to the created job file.
+
         """
         set_umask()
         if "Presets" in self.__config.keys():
             if preset and preset.lower() not in self.__config["Presets"].keys():
                 raise ValueError(
-                    f"Unrecognized preset {preset}. Valid presets are: {', '.join(self.__config['Presets'].keys())}"
+                    f"Unrecognized preset {preset}. Valid presets are: {', '.join(self.__config['Presets'].keys())}",
                 )
 
             job_preset = self.__config["Presets"][preset]
@@ -356,7 +358,7 @@ class Job_builder:
                 outfile_param = ""
                 errfile_param = ""
                 warn(
-                    "Unrecognized job scheduler. Please review the PBS file and or specify a job scheduler between Torque or Slurm"
+                    "Unrecognized job scheduler. Please review the PBS file and or specify a job scheduler between Torque or Slurm",
                 )
 
         job_file.append(f"{prefix} {name_param}{jobname}")
@@ -369,7 +371,7 @@ class Job_builder:
         uid = date_id + str(
             len(glob.glob(Path(outfile).stem[:-2] + "*.out"))
             + len(self.prepared_jobs)
-            + len(self.ongoing_jobs)
+            + len(self.ongoing_jobs),
         ).zfill(3)
 
         outfile = Path(outfile).with_stem(f"{Path(outfile).stem}{uid}")
@@ -385,8 +387,8 @@ class Job_builder:
         # The env_script should contain all the command(s) needed to load the script, with the $env_name template where the environment name should be.
         job_file.append(
             Template(f"\n{env_script if env_script else self.env_script}").substitute(
-                env_name=env_name
-            )
+                env_name=env_name,
+            ),
         )
 
         #! SCRIPT
@@ -423,23 +425,23 @@ class Job_builder:
 
     # TODO support multiple dependencies and job chaining (?)
     def submit_job(
-        self, jobfile: str = None, dependency: str | List[str] = None
+        self, jobfile: str = None, dependency: str | List[str] = None,
     ) -> List[str]:
         """Submits the job file to the cluster using the job scheduler written in the file name or in the configuration file.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
             jobfile: `str`
                 The absolute path of the job file to be submitted. If none is provided, all the prepared job files will be submitted.
 
             dependency: `str` or `list(str)`
                 The job ID this job is dependent on. The afterok:dependency will be added to the command for all jobs submitted.
 
-        Returns:
-        --------
+        Returns
+        -------
             A list containing the job ids of the submitted jobs.
-        """
 
+        """
         jobinfo_list = (
             [{"path": jobfile}] if jobfile is not None else copy(self.prepared_jobs)
         )
@@ -448,7 +450,7 @@ class Job_builder:
 
         if isinstance(dependency, list):
             dependency = ":".join(dependency)
-            
+
         # TODO: Think about the issue when a job have too many dependencies and workaround.
 
         for i, jobinfo in enumerate(jobinfo_list):
@@ -460,7 +462,7 @@ class Job_builder:
                     else ["qsub", str(jobinfo["path"])]
                 )
                 jobid = (
-                    subprocess.run(cmd, stdout=subprocess.PIPE)
+                    subprocess.run(cmd, stdout=subprocess.PIPE, check=False)
                     .stdout.decode("utf-8")
                     .rstrip("\n")
                 )
@@ -470,7 +472,7 @@ class Job_builder:
                 dep = f"-d afterok:{dependency}" if dependency else ""
                 jobid = (
                     subprocess.run(
-                        ["sbatch", dep, jobinfo["path"]], stdout=subprocess.PIPE
+                        ["sbatch", dep, jobinfo["path"]], stdout=subprocess.PIPE, check=False,
                     )
                     .stdout.decode("utf-8")
                     .rstrip("\n")
@@ -495,7 +497,6 @@ class Job_builder:
 
     def update_job_access(self):
         """In case the output files are not accessible by anyone but the owner, running this once will update the permissions for anyone to read them."""
-
         for job_info in self.finished_jobs:
             try:
                 if job_info["outfile"].exists():
@@ -513,7 +514,7 @@ class Job_builder:
             res += "==== PREPARED JOBS ====\n\n"
         for job_info in self.prepared_jobs:
             created_at = datetime.strptime(
-                today + job_info["outfile"].stem[-11:-3], "%d%m%y%H-%M-%S"
+                today + job_info["outfile"].stem[-11:-3], "%d%m%y%H-%M-%S",
             )
             res += (
                 f"{job_info['job_name']} (created at {created_at}) : ready to start.\n"
@@ -523,7 +524,7 @@ class Job_builder:
             res += "==== ONGOING JOBS ====\n\n"
         for job_info in self.ongoing_jobs:
             created_at = datetime.strptime(
-                today + job_info["outfile"].stem[-11:-3], "%d%m%y%H-%M-%S"
+                today + job_info["outfile"].stem[-11:-3], "%d%m%y%H-%M-%S",
             )
             delta = datetime.now() - created_at
             strftime = f"{'%H hours, ' if delta.seconds >= 3600 else ''}{'%M minutes and ' if delta.seconds >= 60 else ''}%S seconds"
@@ -534,7 +535,7 @@ class Job_builder:
             res += "==== FINISHED JOBS ====\n\n"
         for job_info in self.finished_jobs:
             created_at = datetime.strptime(
-                today + job_info["outfile"].stem[-11:-3], "%d%m%y%H-%M-%S"
+                today + job_info["outfile"].stem[-11:-3], "%d%m%y%H-%M-%S",
             )
 
             if not job_info["outfile"].exists():
@@ -542,7 +543,7 @@ class Job_builder:
             else:
                 delta = (
                     datetime.fromtimestamp(
-                        time.mktime(time.localtime(job_info["outfile"].stat().st_ctime))
+                        time.mktime(time.localtime(job_info["outfile"].stat().st_ctime)),
                     )
                     - created_at
                 )
@@ -571,21 +572,22 @@ class Job_builder:
                 The type of the output file to read, whether standard (out) or error (err). The default is out.
             job_file_name: `str`, optional, keyword-only
                 The path to the job_file to read, which can be retrieved easily from Job_builder.finished_jobs. If not provided, then the first element of the list will be read.
+
         """
         if outtype not in ["out", "err"]:
             raise ValueError(
-                "The outtype must be either out for standard output file or err for error output file."
+                "The outtype must be either out for standard output file or err for error output file.",
             )
 
         if not job_file_name:
             job_id = 0
             if job_name:
                 job_id = get_dict_index_in_list(
-                    self.finished_jobs, "job_name", job_name.rstrip()
+                    self.finished_jobs, "job_name", job_name.rstrip(),
                 )
             elif len(self.finished_jobs) == 0:
                 print(
-                    f"There are no finished jobs in this context. Wait until the {len(self.ongoing_jobs)} ongoing jobs are done before reading the output. Otherwise, you can specify which file you wish to read."
+                    f"There are no finished jobs in this context. Wait until the {len(self.ongoing_jobs)} ongoing jobs are done before reading the output. Otherwise, you can specify which file you wish to read.",
                 )
                 return
 
@@ -595,24 +597,24 @@ class Job_builder:
                 else self.finished_jobs[job_id]["errfile"]
             )
 
-        with open(job_file_name, "r") as f:
+        with open(job_file_name) as f:
             print("".join(f.readlines()))
 
     def delete_job(self, job_identifier: str):
         try:
             job_id = get_dict_index_in_list(
-                self.ongoing_jobs, "job_name", job_identifier.rstrip()
+                self.ongoing_jobs, "job_name", job_identifier.rstrip(),
             )
         except ValueError:
             job_id = get_dict_index_in_list(
-                self.ongoing_jobs, "id", job_identifier.rstrip()
+                self.ongoing_jobs, "id", job_identifier.rstrip(),
             )
 
         jobinfo = self.ongoing_jobs[job_id]
         if "Torque" in str(jobinfo["path"]):
-            subprocess.run(["qdel", jobinfo["id"]])
+            subprocess.run(["qdel", jobinfo["id"]], check=False)
         elif "Slurm" in str(jobinfo["path"]):
-            subprocess.run(["scancel", jobinfo["id"]])
+            subprocess.run(["scancel", jobinfo["id"]], check=False)
         self.__ongoing_jobs.remove(jobinfo)
         self.__cancelled_jobs.append(jobinfo)
 

--- a/src/OSmOSE/job.py
+++ b/src/OSmOSE/job.py
@@ -10,7 +10,7 @@ from string import Template
 from typing import NamedTuple, List, Literal
 from warnings import warn
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime
 from importlib import resources
 from OSmOSE.utils.core_utils import read_config, set_umask, chmod_if_needed
 from OSmOSE.config import *

--- a/src/OSmOSE/jointure.py
+++ b/src/OSmOSE/jointure.py
@@ -12,10 +12,11 @@ from pykdtree.kdtree import KDTree
 ########################################################################################
 
 
-get_era_time = lambda x: (
-    calendar.timegm(x.timetuple()) if isinstance(x, datetime.datetime) else x
-)
-g = lambda x: calendar.timegm(time.strptime(str(x)[:-11], "%Y-%m-%dT%H"))
+def get_era_time(x):
+    return calendar.timegm(x.timetuple()) if isinstance(x, datetime.datetime) else x
+
+def g(x):
+    return calendar.timegm(time.strptime(str(x)[:-11], "%Y-%m-%dT%H"))
 
 
 def rect_interpolation_era(stamps, var, method="linear"):

--- a/src/OSmOSE/jointure.py
+++ b/src/OSmOSE/jointure.py
@@ -1,5 +1,7 @@
 import numpy as np
-import time, calendar, datetime
+import time
+import calendar
+import datetime
 import scipy.interpolate as inter
 from pykdtree.kdtree import KDTree
 

--- a/src/OSmOSE/jointure.py
+++ b/src/OSmOSE/jointure.py
@@ -1,7 +1,8 @@
-import numpy as np
-import time
 import calendar
 import datetime
+import time
+
+import numpy as np
 import scipy.interpolate as inter
 from pykdtree.kdtree import KDTree
 
@@ -47,17 +48,16 @@ def time_interpolation(time, var, method="linear"):
 def interpolation_gps(time, latitude, longitude, depth=None, method="linear"):
     interp_lat = inter.interp1d(time, latitude, kind=method)
     interp_lon = inter.interp1d(time, longitude, kind=method)
-    if isinstance(depth, type(None)):
+    if depth is None:
         return interp_lat, interp_lon
-    else:
-        interp_depth = inter.interp1d(time, depth, kind=method)
-        return interp_lat, interp_lon, interp_depth
+    interp_depth = inter.interp1d(time, depth, kind=method)
+    return interp_lat, interp_lon, interp_depth
 
 
 def apply_interp(interp, date, latitude=None, longitude=None, gps=None):
     if isinstance(interp, inter.interp1d):
         return interp(date)
-    elif isinstance(interp, inter.RegularGridInterpolator):
+    if isinstance(interp, inter.RegularGridInterpolator):
         return interp(np.stack((date, latitude, longitude), axis=1))
 
 

--- a/src/OSmOSE/jointure.py
+++ b/src/OSmOSE/jointure.py
@@ -16,6 +16,7 @@ from pykdtree.kdtree import KDTree
 def get_era_time(x):
     return calendar.timegm(x.timetuple()) if isinstance(x, datetime.datetime) else x
 
+
 def g(x):
     return calendar.timegm(time.strptime(str(x)[:-11], "%Y-%m-%dT%H"))
 

--- a/src/OSmOSE/utils/__init__.py
+++ b/src/OSmOSE/utils/__init__.py
@@ -1,5 +1,0 @@
-from OSmOSE.utils.core_utils import *
-from OSmOSE.utils.path_utils import *
-from OSmOSE.utils.timestamp_utils import *
-from OSmOSE.utils.audio_utils import *
-from OSmOSE.utils.postprocess_utils import *

--- a/src/OSmOSE/utils/audio_utils.py
+++ b/src/OSmOSE/utils/audio_utils.py
@@ -1,10 +1,10 @@
-from OSmOSE.config import SUPPORTED_AUDIO_FORMAT
 from pathlib import Path
+
+from OSmOSE.config import SUPPORTED_AUDIO_FORMAT
 
 
 def is_supported_audio_format(filename: Path) -> bool:
-    """
-    Check if a given file is a supported audio file based on its extension.
+    """Check if a given file is a supported audio file based on its extension.
 
     Parameters
     ----------
@@ -16,13 +16,13 @@ def is_supported_audio_format(filename: Path) -> bool:
     bool
         True if the file has an extension that matches a supported audio format,
         False otherwise.
+
     """
     return filename.suffix.lower() in SUPPORTED_AUDIO_FORMAT
 
 
 def get_all_audio_files(directory: Path) -> list[Path]:
-    """
-    Retrieve all supported audio files from a given directory.
+    """Retrieve all supported audio files from a given directory.
 
     Parameters
     ----------
@@ -34,6 +34,7 @@ def get_all_audio_files(directory: Path) -> list[Path]:
     list[Path]
         A list of `Path` objects corresponding to the supported audio files
         found in the directory.
+
     """
     return sorted(
         file

--- a/src/OSmOSE/utils/core_utils.py
+++ b/src/OSmOSE/utils/core_utils.py
@@ -13,14 +13,15 @@ import pandas as pd
 import json
 
 try:
-    import pwd
     import tomllib
 except ModuleNotFoundError:
     import tomli as tomllib
 
 import soundfile as sf
 import numpy as np
-from OSmOSE.config import *
+from OSmOSE.config import OSMOSE_PATH
+import re
+import datetime as dt
 
 
 def display_folder_storage_info(dir_path: str) -> None:

--- a/src/OSmOSE/utils/core_utils.py
+++ b/src/OSmOSE/utils/core_utils.py
@@ -54,7 +54,8 @@ def list_not_built_dataset(path_osmose: str, project: str = None) -> None:
     ]
 
     dataset_list = sorted(
-        dataset_list, key=lambda path: str(path).lower(),
+        dataset_list,
+        key=lambda path: str(path).lower(),
     )  # case insensitive alphabetical sorting of datasets
 
     list_not_built_dataset = []
@@ -80,7 +81,8 @@ def list_not_built_dataset(path_osmose: str, project: str = None) -> None:
                 and timestamp_path
                 and timestamp_path.exists()
                 and not dataset_directory.joinpath(
-                    OSMOSE_PATH.raw_audio, "original",
+                    OSMOSE_PATH.raw_audio,
+                    "original",
                 ).exists()
             ):
                 list_not_built_dataset.append(dataset_directory)
@@ -120,7 +122,8 @@ def list_dataset(path_osmose: str, project: str = None) -> None:
     ]
 
     dataset_list = sorted(
-        dataset_list, key=lambda path: str(path).lower(),
+        dataset_list,
+        key=lambda path: str(path).lower(),
     )  # case insensitive alphabetical sorting of datasets
 
     list_built_dataset = []
@@ -146,7 +149,8 @@ def list_dataset(path_osmose: str, project: str = None) -> None:
                 and timestamp_path
                 and timestamp_path.exists()
                 and not dataset_directory.joinpath(
-                    OSMOSE_PATH.raw_audio, "original",
+                    OSMOSE_PATH.raw_audio,
+                    "original",
                 ).exists()
             ):
                 list_built_dataset.append(dataset_directory)
@@ -190,7 +194,8 @@ def list_aplose(path_osmose: str, project: str = ""):
     ]
 
     dataset_list = sorted(
-        dataset_list, key=lambda path: str(path).lower(),
+        dataset_list,
+        key=lambda path: str(path).lower(),
     )  # case insensitive alphabetical sorting of datasets
 
     list_built_dataset = []
@@ -228,7 +233,9 @@ def list_aplose(path_osmose: str, project: str = ""):
             [
                 f"  - {dataset.name}\n\tresult file: {r.name}\n\ttask status file: {ts.name}"
                 for dataset, r, ts in zip(
-                    list_built_dataset, list_aplose_result, list_aplose_task_status,
+                    list_built_dataset,
+                    list_aplose_result,
+                    list_aplose_task_status,
                 )
             ],
         )
@@ -351,7 +358,8 @@ def read_header(file: str) -> Tuple[int, float, int, int, int]:
                     # Process the fmt chunk
                     fmt_chunk_data = fh.read(subchunk_size)
                     _, channels, samplerate, _, _, sampwidth = struct.unpack(
-                        "<HHIIHH", fmt_chunk_data[:16],
+                        "<HHIIHH",
+                        fmt_chunk_data[:16],
                     )
                     break
                 fh.seek(subchunk_size, 1)
@@ -407,7 +415,11 @@ def read_header(file: str) -> Tuple[int, float, int, int, int]:
 
 
 def safe_read(
-    file_path: str, *, nan: float = 0.0, posinf: any = None, neginf: any = None,
+    file_path: str,
+    *,
+    nan: float = 0.0,
+    posinf: any = None,
+    neginf: any = None,
 ) -> Tuple[np.ndarray, int]:
     """Open a file using Soundfile and clean up the data to be used safely
     Currently, only checks for `NaN`, `inf` and `-inf` presence. The default behavior is the same as `np.nan_to_num`:
@@ -618,13 +630,20 @@ def extract_config(
 
     for project_ID, dataset_ID in zip(list_project_ID, list_dataset_ID):
         dataset_resolution = check_available_file_resolution(
-            path_osmose, project_ID, dataset_ID,
+            path_osmose,
+            project_ID,
+            dataset_ID,
         )
 
         for dr in dataset_resolution:
             ### audio config files
             path1 = os.path.join(
-                path_osmose, project_ID, dataset_ID, "data", "audio", dr,
+                path_osmose,
+                project_ID,
+                dataset_ID,
+                "data",
+                "audio",
+                dr,
             )
             files1 = glob.glob(os.path.join(path1, "**.csv"))
 
@@ -635,7 +654,11 @@ def extract_config(
 
         ### spectro config files
         path2 = os.path.join(
-            path_osmose, project_ID, dataset_ID, "processed", "spectrogram",
+            path_osmose,
+            project_ID,
+            dataset_ID,
+            "processed",
+            "spectrogram",
         )
         files2 = []
         for root, dirs, files in os.walk(path2):
@@ -656,7 +679,9 @@ def extract_config(
 
 
 def extract_datetime(
-    var: str, tz: pytz._FixedOffset = None, formats=None,
+    var: str,
+    tz: pytz._FixedOffset = None,
+    formats=None,
 ) -> Union[pd.Timestamp, str]:
     """Extracts datetime from filename based on the date format
 
@@ -752,7 +777,8 @@ def add_entry_for_APLOSE(path: str, file: str, info: pd.DataFrame):
     if dataset_csv.exists():
         meta = pd.read_csv(dataset_csv)
         meta = pd.concat([meta, info], ignore_index=True).sort_values(
-            by=["path", "dataset"], ascending=True,
+            by=["path", "dataset"],
+            ascending=True,
         )
         meta.to_csv(dataset_csv, index=False)
 

--- a/src/OSmOSE/utils/core_utils.py
+++ b/src/OSmOSE/utils/core_utils.py
@@ -1,27 +1,30 @@
+import glob
+import json
+import math
 import os
-from warnings import warn
-from pathlib import Path
-from importlib.resources import as_file
 import random
 import shutil
 import struct
-from typing import Union, NamedTuple, Tuple, List
-import pytz
-import glob
-import math
+from importlib.resources import as_file
+from pathlib import Path
+from typing import List, NamedTuple, Tuple, Union
+from warnings import warn
+
 import pandas as pd
-import json
+import pytz
 
 try:
     import tomllib
 except ModuleNotFoundError:
     import tomli as tomllib
 
-import soundfile as sf
-import numpy as np
-from OSmOSE.config import OSMOSE_PATH
-import re
 import datetime as dt
+import re
+
+import numpy as np
+import soundfile as sf
+
+from OSmOSE.config import OSMOSE_PATH
 
 
 def display_folder_storage_info(dir_path: str) -> None:
@@ -40,8 +43,8 @@ def list_not_built_dataset(path_osmose: str, project: str = None) -> None:
     dataset_folder_path: str
         The path to the directory containing the project/datasets.
     project: str
-        Name of the project folder containing the datasets."""
-
+        Name of the project folder containing the datasets.
+    """
     ds_folder = Path(path_osmose, project)
 
     dataset_list = [
@@ -51,7 +54,7 @@ def list_not_built_dataset(path_osmose: str, project: str = None) -> None:
     ]
 
     dataset_list = sorted(
-        dataset_list, key=lambda path: str(path).lower()
+        dataset_list, key=lambda path: str(path).lower(),
     )  # case insensitive alphabetical sorting of datasets
 
     list_not_built_dataset = []
@@ -66,7 +69,7 @@ def list_not_built_dataset(path_osmose: str, project: str = None) -> None:
             )
             timestamp_path = next(
                 dataset_directory.joinpath(OSMOSE_PATH.raw_audio).rglob(
-                    "timestamp.csv"
+                    "timestamp.csv",
                 ),
                 None,
             )
@@ -77,7 +80,7 @@ def list_not_built_dataset(path_osmose: str, project: str = None) -> None:
                 and timestamp_path
                 and timestamp_path.exists()
                 and not dataset_directory.joinpath(
-                    OSMOSE_PATH.raw_audio, "original"
+                    OSMOSE_PATH.raw_audio, "original",
                 ).exists()
             ):
                 list_not_built_dataset.append(dataset_directory)
@@ -85,16 +88,16 @@ def list_not_built_dataset(path_osmose: str, project: str = None) -> None:
             list_unknown_dataset.append(dataset_directory)
 
     not_built_formatted = "\n".join(
-        [f"  - {dataset.name}" for dataset in list_not_built_dataset]
+        [f"  - {dataset.name}" for dataset in list_not_built_dataset],
     )
     print(f"""List of the datasets that are not built yet:\n\n{not_built_formatted}""")
 
     if list_unknown_dataset:
         unreachable_formatted = "\n".join(
-            [f"  - {dataset.name}" for dataset in list_unknown_dataset]
+            [f"  - {dataset.name}" for dataset in list_unknown_dataset],
         )
         print(
-            f"""List of unreachable datasets (probably due to insufficient permissions):\n\n{unreachable_formatted}"""
+            f"""List of unreachable datasets (probably due to insufficient permissions):\n\n{unreachable_formatted}""",
         )
 
 
@@ -106,8 +109,8 @@ def list_dataset(path_osmose: str, project: str = None) -> None:
     dataset_folder_path: str
         The path to the directory containing the project/datasets.
     project: str
-        Name of the project folder containing the datasets."""
-
+        Name of the project folder containing the datasets.
+    """
     ds_folder = Path(path_osmose, project)
 
     dataset_list = [
@@ -117,7 +120,7 @@ def list_dataset(path_osmose: str, project: str = None) -> None:
     ]
 
     dataset_list = sorted(
-        dataset_list, key=lambda path: str(path).lower()
+        dataset_list, key=lambda path: str(path).lower(),
     )  # case insensitive alphabetical sorting of datasets
 
     list_built_dataset = []
@@ -132,7 +135,7 @@ def list_dataset(path_osmose: str, project: str = None) -> None:
             )
             timestamp_path = next(
                 dataset_directory.joinpath(OSMOSE_PATH.raw_audio).rglob(
-                    "timestamp.csv"
+                    "timestamp.csv",
                 ),
                 None,
             )
@@ -143,7 +146,7 @@ def list_dataset(path_osmose: str, project: str = None) -> None:
                 and timestamp_path
                 and timestamp_path.exists()
                 and not dataset_directory.joinpath(
-                    OSMOSE_PATH.raw_audio, "original"
+                    OSMOSE_PATH.raw_audio, "original",
                 ).exists()
             ):
                 list_built_dataset.append(dataset_directory)
@@ -153,7 +156,7 @@ def list_dataset(path_osmose: str, project: str = None) -> None:
 
     if list_built_dataset:
         built_formatted = "\n".join(
-            [f"  - {dataset.name}" for dataset in list_built_dataset]
+            [f"  - {dataset.name}" for dataset in list_built_dataset],
         )
         print(f"""List of the built datasets under {ds_folder}:\n\n{built_formatted}""")
     else:
@@ -161,10 +164,10 @@ def list_dataset(path_osmose: str, project: str = None) -> None:
 
     if list_unknown_dataset:
         unreachable_formatted = "\n".join(
-            [f"  - {dataset.name}" for dataset in list_unknown_dataset]
+            [f"  - {dataset.name}" for dataset in list_unknown_dataset],
         )
         print(
-            f"""List of unreachable datasets (probably due to insufficient permissions):\n\n{unreachable_formatted}"""
+            f"""List of unreachable datasets (probably due to insufficient permissions):\n\n{unreachable_formatted}""",
         )
 
 
@@ -176,8 +179,8 @@ def list_aplose(path_osmose: str, project: str = ""):
     dataset_folder_path: str
         The path to the directory containing the project / datasets.
     project: str
-        Name of the project folder containing the datasets."""
-
+        Name of the project folder containing the datasets.
+    """
     ds_folder = Path(path_osmose, project)
 
     dataset_list = [
@@ -187,7 +190,7 @@ def list_aplose(path_osmose: str, project: str = ""):
     ]
 
     dataset_list = sorted(
-        dataset_list, key=lambda path: str(path).lower()
+        dataset_list, key=lambda path: str(path).lower(),
     )  # case insensitive alphabetical sorting of datasets
 
     list_built_dataset = []
@@ -225,22 +228,22 @@ def list_aplose(path_osmose: str, project: str = ""):
             [
                 f"  - {dataset.name}\n\tresult file: {r.name}\n\ttask status file: {ts.name}"
                 for dataset, r, ts in zip(
-                    list_built_dataset, list_aplose_result, list_aplose_task_status
+                    list_built_dataset, list_aplose_result, list_aplose_task_status,
                 )
-            ]
+            ],
         )
         print(
-            f"""List of the datasets with APLOSE result files under {ds_folder}:\n\n{aplose_formatted}"""
+            f"""List of the datasets with APLOSE result files under {ds_folder}:\n\n{aplose_formatted}""",
         )
     else:
         print(f"No dataset with APLOSE result files found under '{ds_folder}'")
 
     if list_unknown_dataset:
         unreachable_formatted = "\n".join(
-            [f"  - {dataset.name}" for dataset in list_unknown_dataset]
+            [f"  - {dataset.name}" for dataset in list_unknown_dataset],
         )
         print(
-            f"""List of unreachable datasets (probably due to insufficient permissions):\n\n{unreachable_formatted}"""
+            f"""List of unreachable datasets (probably due to insufficient permissions):\n\n{unreachable_formatted}""",
         )
 
 
@@ -264,8 +267,9 @@ def read_config(raw_config: Union[str, dict, Path]) -> NamedTuple:
     TypeError
         Raised if the raw_config is anything else than a string, a PurePath or a dict.
     NotImplementedError
-        Raised if the raw_config file is in YAML format"""
+        Raised if the raw_config file is in YAML format
 
+    """
     match raw_config:
         case Path():
             with as_file(raw_config) as input_config:
@@ -274,14 +278,14 @@ def read_config(raw_config: Union[str, dict, Path]) -> NamedTuple:
         case str():
             if not Path(raw_config).is_file:
                 raise FileNotFoundError(
-                    f"The configuration file {raw_config} does not exist."
+                    f"The configuration file {raw_config} does not exist.",
                 )
 
         case dict():
             pass
         case _:
             raise TypeError(
-                "The raw_config must be either of type str, dict or Traversable."
+                "The raw_config must be either of type str, dict or Traversable.",
             )
 
     if not isinstance(raw_config, dict):
@@ -293,11 +297,11 @@ def read_config(raw_config: Union[str, dict, Path]) -> NamedTuple:
                     raw_config = json.load(input_config)
                 case ".yaml":
                     raise NotImplementedError(
-                        "YAML support will eventually get there (unfortunately)"
+                        "YAML support will eventually get there (unfortunately)",
                     )
                 case _:
                     raise FileNotFoundError(
-                        f"The provided configuration file extension ({Path(raw_config).suffix} is not a valid extension. Please use .toml or .json files."
+                        f"The provided configuration file extension ({Path(raw_config).suffix} is not a valid extension. Please use .toml or .json files.",
                     )
 
     return raw_config
@@ -311,7 +315,8 @@ def read_header(file: str) -> Tuple[int, float, int, int, int]:
     ---------
     file: str
         The absolute path of the audio file whose header will be read.
-    Returns
+
+    Returns:
     -------
     samplerate : `int`
         The number of samples in one frame.
@@ -321,10 +326,12 @@ def read_header(file: str) -> Tuple[int, float, int, int, int]:
         The number of audio channels.
     sampwidth : `int`
         The sample width.
-    Note
+
+    Note:
     ----
     When there is no `data` chunk, the `frames` value will fall back on the size written in the header. This can be incorrect,
     if the file has been corrupted or the writing process has been interrupted before completion.
+
     """
     with open(file, "rb") as fh:
         header = fh.read(4)
@@ -344,11 +351,10 @@ def read_header(file: str) -> Tuple[int, float, int, int, int]:
                     # Process the fmt chunk
                     fmt_chunk_data = fh.read(subchunk_size)
                     _, channels, samplerate, _, _, sampwidth = struct.unpack(
-                        "<HHIIHH", fmt_chunk_data[:16]
+                        "<HHIIHH", fmt_chunk_data[:16],
                     )
                     break
-                else:
-                    fh.seek(subchunk_size, 1)
+                fh.seek(subchunk_size, 1)
 
             chunkOffset = fh.tell()
             found_data = False
@@ -362,7 +368,7 @@ def read_header(file: str) -> Tuple[int, float, int, int, int]:
 
             if not found_data:
                 print(
-                    "No data chunk found while reading the header. Will fallback on the header size."
+                    "No data chunk found while reading the header. Will fallback on the header size.",
                 )
                 subchunk2size = size - 36
 
@@ -372,7 +378,7 @@ def read_header(file: str) -> Tuple[int, float, int, int, int]:
 
             return samplerate, frames, sampwidth, channels, size
 
-        elif header == b"fLaC":
+        if header == b"fLaC":
             # FLAC file processing
             is_last = False
             while not is_last:
@@ -395,18 +401,18 @@ def read_header(file: str) -> Tuple[int, float, int, int, int]:
 
                     return samplerate, frames, sampwidth, channels, size
                     break
-                else:
-                    fh.seek(block_size, 1)  # Skip this block
+                fh.seek(block_size, 1)  # Skip this block
         else:
             raise ValueError("Unsupported file format")
 
 
 def safe_read(
-    file_path: str, *, nan: float = 0.0, posinf: any = None, neginf: any = None
+    file_path: str, *, nan: float = 0.0, posinf: any = None, neginf: any = None,
 ) -> Tuple[np.ndarray, int]:
     """Open a file using Soundfile and clean up the data to be used safely
     Currently, only checks for `NaN`, `inf` and `-inf` presence. The default behavior is the same as `np.nan_to_num`:
     `NaNs` are transformed into 0.0, `inf` and `-inf` are transformed into the maximum and minimum values of their dtype.
+
     Parameters
     ----------
         file_path: `str`
@@ -417,12 +423,15 @@ def safe_read(
             The value that will replace `inf`. Default behavior is the maximum value of the data type.
         neginf: `any`, optional, keyword_only
             The value that will replace `-inf`. Default behavior is the minimum value of the data type.
+
     Returns
     -------
         audio_data: `NDArray`
             The cleaned audio data as a numpy array.
         sample_rate: `int`
-            The sample rate of the data."""
+            The sample rate of the data.
+
+    """
     audio_data, sample_rate = sf.read(file_path)
 
     nan_nb = sum(np.isnan(audio_data))
@@ -431,7 +440,7 @@ def safe_read(
 
     if nan_nb > 0:
         warn(
-            f"{nan_nb} NaN detected in file {Path(file_path).name}. They will be replaced with {nan}."
+            f"{nan_nb} NaN detected in file {Path(file_path).name}. They will be replaced with {nan}.",
         )
 
     np.nan_to_num(audio_data, copy=False, nan=nan, posinf=posinf, neginf=neginf)
@@ -450,6 +459,7 @@ def check_n_files(
     Currently, check if the data for wav in PCM float format are between -1.0 and 1.0. If the number of files that
     fail the test is higher than the threshold (which is 10% of n by default, with an absolute minimum of 1), all the
     dataset will be normalized and written in another file.
+
     Parameters
     ----------
         file_list: `list`
@@ -462,14 +472,14 @@ def check_n_files(
             it must have a value.
         auto_normalization: `bool`, optional, keyword_only
             Whether the normalization should proceed automatically or not if the threshold is reached. As a safeguard, the default is False.
+
     Returns
     -------
         normalized: `bool`
             Indicates whether or not the dataset has been normalized.
-    """
 
-    if n > len(file_list):
-        n = len(file_list)
+    """
+    n = min(n, len(file_list))
 
     # if "float" in str(sf.info(file_list[0])): # to understand
     bad_files = []
@@ -503,7 +513,7 @@ def get_timestamp_of_audio_file(path_timestamp_file: Path, audio_file_name: str)
     timestamps = pd.read_csv(path_timestamp_file)
     # get timestamp of the audio file
     return str(
-        timestamps["timestamp"][timestamps["filename"] == audio_file_name].values[0]
+        timestamps["timestamp"][timestamps["filename"] == audio_file_name].values[0],
     )
 
 
@@ -511,7 +521,7 @@ def t_rounder(t: pd.Timestamp, res: int) -> pd.Timestamp:
     """Rounds a Timestamp according to the user specified resolution : 10s / 1min / 10 min / 1h / 24h
 
     Parameters
-    -------
+    ----------
         t: pd.Timestamp
             Timestamp to round
         res: 'int'
@@ -521,8 +531,8 @@ def t_rounder(t: pd.Timestamp, res: int) -> pd.Timestamp:
     -------
         t: pd.Timestamp
             rounded Timestamp
-    """
 
+    """
     if res == 600:  # 10min
         minute = t.minute
         minute = math.floor(minute / 10) * 10
@@ -548,7 +558,7 @@ def check_available_file_resolution(path_osmose: str, project_ID: str, dataset_I
     """Lists the file resolution for a given dataset
 
     Parameters
-    ---------
+    ----------
     path_osmose: 'str'
         usually '/home/datawork-osmose/dataset/'
 
@@ -561,8 +571,8 @@ def check_available_file_resolution(path_osmose: str, project_ID: str, dataset_I
     Returns
     -------
     The list of the dataset resolutions is being printed and returned as a list of str
-    """
 
+    """
     base_path = os.path.join(path_osmose, project_ID, dataset_ID, "data", "audio")
     resolution = os.listdir(base_path)
 
@@ -586,7 +596,7 @@ def extract_config(
     for the spectrogram configuration as well.
 
     Parameters
-    ---------
+    ----------
     path_osmose: 'str'
         usually '/home/datawork-osmose/dataset/'
 
@@ -601,20 +611,20 @@ def extract_config(
 
     Returns
     -------
-    """
 
+    """
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
     for project_ID, dataset_ID in zip(list_project_ID, list_dataset_ID):
         dataset_resolution = check_available_file_resolution(
-            path_osmose, project_ID, dataset_ID
+            path_osmose, project_ID, dataset_ID,
         )
 
         for dr in dataset_resolution:
             ### audio config files
             path1 = os.path.join(
-                path_osmose, project_ID, dataset_ID, "data", "audio", dr
+                path_osmose, project_ID, dataset_ID, "data", "audio", dr,
             )
             files1 = glob.glob(os.path.join(path1, "**.csv"))
 
@@ -625,7 +635,7 @@ def extract_config(
 
         ### spectro config files
         path2 = os.path.join(
-            path_osmose, project_ID, dataset_ID, "processed", "spectrogram"
+            path_osmose, project_ID, dataset_ID, "processed", "spectrogram",
         )
         files2 = []
         for root, dirs, files in os.walk(path2):
@@ -634,7 +644,7 @@ def extract_config(
                     os.path.join(root, file)
                     for file in files
                     if file.lower().endswith(".csv")
-                ]
+                ],
             )
 
         full_path2 = os.path.join(out_dir, "export_" + dataset_ID, "spectro")
@@ -646,12 +656,12 @@ def extract_config(
 
 
 def extract_datetime(
-    var: str, tz: pytz._FixedOffset = None, formats=None
+    var: str, tz: pytz._FixedOffset = None, formats=None,
 ) -> Union[pd.Timestamp, str]:
     """Extracts datetime from filename based on the date format
 
     Parameters
-    -------
+    ----------
         var: 'str'
             name of the wav file
         tz: pytz._FixedOffset
@@ -660,12 +670,13 @@ def extract_datetime(
             The date template in strftime format.
             For example, `2017/02/24` has the template `%Y/%m/%d`
             For more information on strftime template, see https://strftime.org/
+
     Returns
     -------
         date_obj: pd.Timestamp
             datetime corresponding to the datetime found in var
-    """
 
+    """
     if formats is None:
         # add more format if necessary
         formats = [
@@ -708,7 +719,7 @@ def extract_datetime(
 
         if tz is None:
             return date_obj
-        elif type(tz) is dt.timezone:
+        if type(tz) is dt.timezone:
             offset_minutes = tz.utcoffset(None).total_seconds() / 60
             pytz_fixed_offset = pytz.FixedOffset(int(offset_minutes))
             date_obj = pytz_fixed_offset.localize(date_obj)
@@ -716,15 +727,14 @@ def extract_datetime(
             date_obj = tz.localize(date_obj)
 
         return date_obj
-    else:
-        raise ValueError(f"{var}: No datetime found")
+    raise ValueError(f"{var}: No datetime found")
 
 
 def add_entry_for_APLOSE(path: str, file: str, info: pd.DataFrame):
     """Add entry for APLOSE dataset csv file
 
     Parameters
-    -------
+    ----------
         path: 'str'
             path to the file
         file: 'str'
@@ -732,6 +742,7 @@ def add_entry_for_APLOSE(path: str, file: str, info: pd.DataFrame):
         info: 'DataFrame'
             info of the entry
             'path' / 'dataset' / 'spectro_duration' / 'dataset_sr' / 'files_type'
+
     Returns
     -------
 
@@ -741,7 +752,7 @@ def add_entry_for_APLOSE(path: str, file: str, info: pd.DataFrame):
     if dataset_csv.exists():
         meta = pd.read_csv(dataset_csv)
         meta = pd.concat([meta, info], ignore_index=True).sort_values(
-            by=["path", "dataset"], ascending=True
+            by=["path", "dataset"], ascending=True,
         )
         meta.to_csv(dataset_csv, index=False)
 
@@ -754,5 +765,5 @@ def chmod_if_needed(path: Path, mode: int):
         os.chmod(path, mode)
     except PermissionError:
         raise PermissionError(
-            f"You do not have the permission to write to {path}, nor to change its permissions."
+            f"You do not have the permission to write to {path}, nor to change its permissions.",
         )

--- a/src/OSmOSE/utils/core_utils.py
+++ b/src/OSmOSE/utils/core_utils.py
@@ -5,9 +5,7 @@ from importlib.resources import as_file
 import random
 import shutil
 import struct
-from collections import namedtuple
-import sys
-from typing import Union, NamedTuple, Tuple, List, Literal
+from typing import Union, NamedTuple, Tuple, List
 import pytz
 import glob
 import math
@@ -474,7 +472,7 @@ def check_n_files(
 
     # if "float" in str(sf.info(file_list[0])): # to understand
     bad_files = []
-    print(f"Testing whether samples are within [-1,1] for the following audio files:")
+    print("Testing whether samples are within [-1,1] for the following audio files:")
     for audio_file in random.sample(file_list, n):
         data, sr = safe_read(audio_file)
         if not (np.max(data) <= 1.0 and np.min(data) >= -1.0):
@@ -482,7 +480,7 @@ def check_n_files(
             print(f"- {audio_file.name} -> FAILED")
         else:
             print(f"- {audio_file.name} -> PASSED")
-    print(f"\n")
+    print("\n")
 
     return len(bad_files)
 

--- a/src/OSmOSE/utils/formatting_utils.py
+++ b/src/OSmOSE/utils/formatting_utils.py
@@ -25,6 +25,7 @@ def aplose2raven(df: pd.DataFrame) -> pd.DataFrame:
 
     # export to Raven format
     df2raven.to_csv('path/to/result/file.txt', sep='\t', index=False) # Raven export tab-separated files with a txt extension
+
     """
     start_time = [
         (st - df["start_datetime"][0]).total_seconds() for st in df["start_datetime"]

--- a/src/OSmOSE/utils/path_utils.py
+++ b/src/OSmOSE/utils/path_utils.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from OSmOSE.config import DPDEFAULT
 
 
@@ -14,6 +15,7 @@ def make_path(path: Path, *, mode=DPDEFAULT) -> Path:
         mode: `int`, optional, keyword-only
             The permission code of the complete path. The default is 0o755, meaning the owner has all permissions over the files of the path,
             and the owner group and others only have read and execute rights, but not writing.
+
     """
     for parent in path.parents[::-1]:
         parent.mkdir(mode=mode, exist_ok=True)
@@ -36,6 +38,6 @@ def str2Path(path: str) -> Path:
     -------
     Path
         The complete path as a Path.
-    """
 
+    """
     return Path(path)

--- a/src/OSmOSE/utils/postprocess_utils.py
+++ b/src/OSmOSE/utils/postprocess_utils.py
@@ -247,13 +247,7 @@ def reshape_timebin(df: pd.DataFrame, timebin_new: int = None) -> pd.DataFrame:
 
     annotators = list(df["annotator"].drop_duplicates())
     labels = list(df["annotation"].drop_duplicates())
-
-    df_nobox = df.loc[
-        (df["start_time"] == 0)
-        & (df["end_time"] == max(df["end_time"]))
-        & (df["end_frequency"] == max(df["end_frequency"]))
-    ]
-    max_time = 0 if len(df_nobox) == 0 else int(max(df["end_time"]))
+    
     max_freq = int(max(df["end_frequency"]))
 
     tz_data = df["start_datetime"][0].tz

--- a/src/OSmOSE/utils/postprocess_utils.py
+++ b/src/OSmOSE/utils/postprocess_utils.py
@@ -111,10 +111,12 @@ def sorting_detections(
 
     # Convert datetime columns to proper format
     df["start_datetime"] = pd.to_datetime(
-        df["start_datetime"], format="%Y-%m-%dT%H:%M:%S.%f%z",
+        df["start_datetime"],
+        format="%Y-%m-%dT%H:%M:%S.%f%z",
     )
     df["end_datetime"] = pd.to_datetime(
-        df["end_datetime"], format="%Y-%m-%dT%H:%M:%S.%f%z",
+        df["end_datetime"],
+        format="%Y-%m-%dT%H:%M:%S.%f%z",
     )
     df = df.sort_values("start_datetime")
 
@@ -251,7 +253,13 @@ def reshape_timebin(df: pd.DataFrame, timebin_new: int = None) -> pd.DataFrame:
 
     tz_data = df["start_datetime"][0].tz
 
-    if timebin_new == 10 or timebin_new == 60 or timebin_new == 600 or timebin_new == 3600 or timebin_new == 86400:
+    if (
+        timebin_new == 10
+        or timebin_new == 60
+        or timebin_new == 600
+        or timebin_new == 3600
+        or timebin_new == 86400
+    ):
         pass
     else:
         raise ValueError(f"Time resolution {timebin_new}s not available")
@@ -274,7 +282,8 @@ def reshape_timebin(df: pd.DataFrame, timebin_new: int = None) -> pd.DataFrame:
 
             t = t_rounder(t=df_detect_prov["start_datetime"].iloc[0], res=timebin_new)
             t2 = t_rounder(
-                df_detect_prov["start_datetime"].iloc[-1], timebin_new,
+                df_detect_prov["start_datetime"].iloc[-1],
+                timebin_new,
             ) + pd.timedelta(seconds=timebin_new)
 
             time_vector = [
@@ -317,9 +326,11 @@ def reshape_timebin(df: pd.DataFrame, timebin_new: int = None) -> pd.DataFrame:
             for i in range(len(times_detect_beg)):
                 for j in range(k, len(time_vector) - 1):
                     if int(times_detect_beg[i] * 1e7) in range(
-                        int(time_vector[j] * 1e7), int(time_vector[j + 1] * 1e7),
+                        int(time_vector[j] * 1e7),
+                        int(time_vector[j + 1] * 1e7),
                     ) or int(times_detect_end[i] * 1e7) in range(
-                        int(time_vector[j] * 1e7), int(time_vector[j + 1] * 1e7),
+                        int(time_vector[j] * 1e7),
+                        int(time_vector[j + 1] * 1e7),
                     ):
                         ranks.append(j)
                         k = j
@@ -341,7 +352,9 @@ def reshape_timebin(df: pd.DataFrame, timebin_new: int = None) -> pd.DataFrame:
                         + start_datetime.strftime("%Y-%m-%dT%H:%M:%S.%f%z")[-2:],
                     )
                     end_datetime = pd.Timestamp(
-                        time_vector[i] + timebin_new, unit="s", tz=tz_data,
+                        time_vector[i] + timebin_new,
+                        unit="s",
+                        tz=tz_data,
                     )
                     end_datetime_str.append(
                         end_datetime.strftime("%Y-%m-%dT%H:%M:%S.%f%z")[:-8]
@@ -411,7 +424,10 @@ def overview(data: pd.DataFrame):
     print(f"---\n\n{summary_annotator.to_string()}")
 
     fig, (ax1, ax2) = plt.subplots(
-        2, figsize=(12, 6), gridspec_kw={"height_ratios": [1, 1]}, facecolor="#36454F",
+        2,
+        figsize=(12, 6),
+        gridspec_kw={"height_ratios": [1, 1]},
+        facecolor="#36454F",
     )
     # ax1 = summary_label.plot(kind='bar', ax=ax1, color=['tab:blue', 'tab:orange'], edgecolor='black', linewidth=1)
     ax1 = summary_label.plot(kind="bar", ax=ax1, edgecolor="black", linewidth=1)
@@ -434,16 +450,30 @@ def overview(data: pd.DataFrame):
 
     # labels
     ax1.set_ylabel(
-        "Number of\nannotated calls", fontsize=15, color="w", multialignment="center",
+        "Number of\nannotated calls",
+        fontsize=15,
+        color="w",
+        multialignment="center",
     )
     ax1.set_xlabel(
-        "Labels", fontsize=10, rotation=0, color="w", multialignment="center",
+        "Labels",
+        fontsize=10,
+        rotation=0,
+        color="w",
+        multialignment="center",
     )
     ax2.set_ylabel(
-        "Number of\nannotated calls", fontsize=15, color="w", multialignment="center",
+        "Number of\nannotated calls",
+        fontsize=15,
+        color="w",
+        multialignment="center",
     )
     ax2.set_xlabel(
-        "Annotator", fontsize=10, rotation=0, color="w", multialignment="center",
+        "Annotator",
+        fontsize=10,
+        rotation=0,
+        color="w",
+        multialignment="center",
     )
 
     # spines
@@ -635,7 +665,9 @@ def single_seasonality(
         ax.set_ylim([0, n_annot_max])
         if reso_bin == "Minutes":
             ax.set_ylabel(
-                f"Detection rate % \n({res_min} min)", fontsize=20, color="w",
+                f"Detection rate % \n({res_min} min)",
+                fontsize=20,
+                color="w",
             )
         else:
             ax.set_ylabel("Detection rate % per month", fontsize=20, color="w")

--- a/src/OSmOSE/utils/postprocess_utils.py
+++ b/src/OSmOSE/utils/postprocess_utils.py
@@ -1,8 +1,5 @@
 import numpy as np
-import os
 import pandas as pd
-import shutil
-import glob
 import pytz
 import csv
 from typing import List
@@ -14,7 +11,6 @@ import bisect
 from OSmOSE.utils.core_utils import (
     t_rounder,
     extract_datetime,
-    check_available_file_resolution,
 )
 
 

--- a/src/OSmOSE/utils/timestamp_utils.py
+++ b/src/OSmOSE/utils/timestamp_utils.py
@@ -1,4 +1,5 @@
 """Utils for working with timestamps."""
+
 import os
 import re
 from datetime import datetime, timedelta

--- a/src/OSmOSE/utils/timestamp_utils.py
+++ b/src/OSmOSE/utils/timestamp_utils.py
@@ -1,4 +1,3 @@
-from collections.abc import Generator
 from datetime import datetime, timedelta
 import pandas as pd
 from typing import List, Iterable

--- a/src/OSmOSE/utils/timestamp_utils.py
+++ b/src/OSmOSE/utils/timestamp_utils.py
@@ -41,7 +41,9 @@ def check_epoch(df):
 
 
 def substract_timestamps(
-    input_timestamp: pd.DataFrame, files: List[str], index: int,
+    input_timestamp: pd.DataFrame,
+    files: List[str],
+    index: int,
 ) -> timedelta:
     """Substracts two timestamp_list from the "timestamp" column of a dataframe at the indexes of files[i] and files[i-1] and returns the time delta between them
 
@@ -216,7 +218,8 @@ def strptime_from_text(text: str, datetime_template: str) -> Timestamp:
 
 
 def associate_timestamps(
-    audio_files: Iterable[str], datetime_template: str,
+    audio_files: Iterable[str],
+    datetime_template: str,
 ) -> pd.Series:
     """Returns a chronologically sorted pandas series containing the audio files as indexes and the extracted timestamp as values.
 
@@ -242,7 +245,10 @@ def associate_timestamps(
 
 
 def get_timestamps(
-    path_osmose_dataset: str, campaign_name: str, dataset_name: str, resolution: str,
+    path_osmose_dataset: str,
+    campaign_name: str,
+    dataset_name: str,
+    resolution: str,
 ) -> pd.DataFrame:
     """Read infos from APLOSE timestamp csv file
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import pytest
 import numpy as np
 import soundfile as sf
 import shutil
-import csv
 from OSmOSE.config import OSMOSE_PATH
 from scipy.signal import chirp
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
-from pathlib import Path
-import pytest
-import numpy as np
-import soundfile as sf
 import shutil
-from OSmOSE.config import OSMOSE_PATH
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
 from scipy.signal import chirp
+
+from OSmOSE.config import OSMOSE_PATH
 
 
 def capture_csv(monkeypatch):
@@ -17,13 +19,16 @@ def input_dataset(tmp_path: Path):
 
     Creates the basic structure of a dataset in a temporary direction, as well as 10 audio files (5 wav and 5 flac) of 3 seconds of random noise at a sample rate of 44100,
      as well as the timestamp.csv file, from 2022-01-01T12:00:00 to 2022-01-01T12:00:30
+
     Returns
     -------
         The paths to the dataset's folders, in order :
         - root directory
         - main audio directory
         - original audio sub-directory
-        - main spectrogram directory."""
+        - main spectrogram directory.
+
+    """
     main_dir = tmp_path.joinpath("sample_dataset")
     main_audio_dir = main_dir.joinpath(OSMOSE_PATH.raw_audio)
     orig_audio_dir = main_audio_dir.joinpath("original")
@@ -53,14 +58,14 @@ def input_dataset(tmp_path: Path):
             sf.write(wav_file, data, rate, format="wav", subtype="FLOAT")
         else:
             flac_file = orig_audio_dir.joinpath(
-                f"20220101_1200{str(3*i).zfill(2)}.flac"
+                f"20220101_1200{str(3*i).zfill(2)}.flac",
             )
             sf.write(flac_file, data, rate, format="flac", subtype="PCM_24")
-    yield dict(
+    return dict(
         zip(
             ["main_dir", "main_audio_dir", "orig_audio_dir", "process_dir"],
             folders_to_create,
-        )
+        ),
     )
 
 
@@ -69,10 +74,13 @@ def input_dir(tmp_path):
     """Creates a temporary input directory with a single audio file.
 
     The file is 3 seconds of random noise at a sample rate of 44100.
+
     Returns
     -------
         input_dir: `Path`
-            The path to the input directory."""
+            The path to the input directory.
+
+    """
     # Parameters
     input_dir = tmp_path / "input"
     input_dir.mkdir()
@@ -86,7 +94,7 @@ def input_dir(tmp_path):
     wav_file = input_dir / "test.wav"
     sf.write(wav_file, data, rate, format="WAV", subtype="FLOAT")
 
-    yield input_dir
+    return input_dir
 
 
 @pytest.fixture
@@ -95,12 +103,14 @@ def output_dir(tmp_path: Path):
 
     Returns
     -------
-        The directory path"""
+        The directory path
+
+    """
     output_dir = tmp_path.joinpath("output")
     if output_dir.is_dir():
         shutil.rmtree(output_dir)
     output_dir.mkdir()
-    yield output_dir
+    return output_dir
 
 
 @pytest.fixture
@@ -114,7 +124,9 @@ def input_spectrogram(input_dataset):
         input_dataset: `Path`
             The path to the dataset directory
         analysis_params: `dict`
-            Dummy analysis parameters"""
+            Dummy analysis parameters
+
+    """
     analysis_params = {
         "nfft": 512,
         "winsize": 512,
@@ -134,7 +146,7 @@ def input_spectrogram(input_dataset):
         "zscore_duration": "original",
     }
 
-    yield input_dataset, analysis_params
+    return input_dataset, analysis_params
 
 
 @pytest.fixture
@@ -146,7 +158,9 @@ def input_reshape(input_dir: Path):
     Returns
     -------
         input_dir: `Path`
-            The path to the input directory."""
+            The path to the input directory.
+
+    """
     for i in range(9):
         wav_file = input_dir.joinpath(f"test{i}.wav")
         shutil.copyfile(input_dir.joinpath("test.wav"), wav_file)

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -1,5 +1,7 @@
-import pytest
 from pathlib import Path
+
+import pytest
+
 from OSmOSE.utils.audio_utils import is_supported_audio_format
 
 

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -1,6 +1,6 @@
 import pytest
 from pathlib import Path
-from OSmOSE.utils.audio_utils import *
+from OSmOSE.utils.audio_utils import is_supported_audio_format
 
 
 @pytest.mark.unit

--- a/tests/test_custom_frequency_scales.py
+++ b/tests/test_custom_frequency_scales.py
@@ -11,13 +11,16 @@ def test_scale_serializer():
     serializer = FrequencyScaleSerializer()
 
     assert isinstance(
-        serializer.get_scale("porp_delph", sr=312500), CustomFrequencyScale,
+        serializer.get_scale("porp_delph", sr=312500),
+        CustomFrequencyScale,
     ), "Error in porp_delph scale"
     assert isinstance(
-        serializer.get_scale("audible", sr=312500), CustomFrequencyScale,
+        serializer.get_scale("audible", sr=312500),
+        CustomFrequencyScale,
     ), "Error in Audible scale"
     assert isinstance(
-        serializer.get_scale("dual_LF_HF", sr=312500), CustomFrequencyScale,
+        serializer.get_scale("dual_LF_HF", sr=312500),
+        CustomFrequencyScale,
     ), "Error in Dual_LF_HF scale"
 
     try:
@@ -52,10 +55,16 @@ def test_custom_scales():
         test_box2 = [0.001, 0.101, 0, 156250]
 
         a, b, c, d = scale.bbox2scale(
-            test_box[0], test_box[1], test_box[2], test_box[3],
+            test_box[0],
+            test_box[1],
+            test_box[2],
+            test_box[3],
         )
         e, f, g, h = scale.bbox2scale(
-            test_box2[0], test_box2[1], test_box2[2], test_box2[3],
+            test_box2[0],
+            test_box2[1],
+            test_box2[2],
+            test_box2[3],
         )
 
         assert np.isclose(scale.scale2bbox(a, b, c, d)[0], test_box[0], rtol=1e-12)
@@ -69,5 +78,7 @@ def test_custom_scales():
             assert np.isclose(scale.scale2bbox(e, f, g, h)[3], test_box2[3], rtol=1e-12)
         else:
             assert np.isclose(
-                scale.scale2bbox(e, f, g, h)[3], scale.frequencies[0], rtol=1e-12,
+                scale.scale2bbox(e, f, g, h)[3],
+                scale.frequencies[0],
+                rtol=1e-12,
             )

--- a/tests/test_custom_frequency_scales.py
+++ b/tests/test_custom_frequency_scales.py
@@ -1,7 +1,6 @@
 from OSmOSE.frequency_scales.custom_frequency_scale import CustomFrequencyScale
 from OSmOSE.frequency_scales.frequency_scale_serializer import FrequencyScaleSerializer
 import numpy as np
-import pytest
 
 configs_to_test = ["porp_delph", "dual_LF_HF", "audible"]
 important_freqs = [22050, 44100, 156250, 312500]

--- a/tests/test_custom_frequency_scales.py
+++ b/tests/test_custom_frequency_scales.py
@@ -1,6 +1,7 @@
+import numpy as np
+
 from OSmOSE.frequency_scales.custom_frequency_scale import CustomFrequencyScale
 from OSmOSE.frequency_scales.frequency_scale_serializer import FrequencyScaleSerializer
-import numpy as np
 
 configs_to_test = ["porp_delph", "dual_LF_HF", "audible"]
 important_freqs = [22050, 44100, 156250, 312500]
@@ -10,13 +11,13 @@ def test_scale_serializer():
     serializer = FrequencyScaleSerializer()
 
     assert isinstance(
-        serializer.get_scale("porp_delph", sr=312500), CustomFrequencyScale
+        serializer.get_scale("porp_delph", sr=312500), CustomFrequencyScale,
     ), "Error in porp_delph scale"
     assert isinstance(
-        serializer.get_scale("audible", sr=312500), CustomFrequencyScale
+        serializer.get_scale("audible", sr=312500), CustomFrequencyScale,
     ), "Error in Audible scale"
     assert isinstance(
-        serializer.get_scale("dual_LF_HF", sr=312500), CustomFrequencyScale
+        serializer.get_scale("dual_LF_HF", sr=312500), CustomFrequencyScale,
     ), "Error in Dual_LF_HF scale"
 
     try:
@@ -51,10 +52,10 @@ def test_custom_scales():
         test_box2 = [0.001, 0.101, 0, 156250]
 
         a, b, c, d = scale.bbox2scale(
-            test_box[0], test_box[1], test_box[2], test_box[3]
+            test_box[0], test_box[1], test_box[2], test_box[3],
         )
         e, f, g, h = scale.bbox2scale(
-            test_box2[0], test_box2[1], test_box2[2], test_box2[3]
+            test_box2[0], test_box2[1], test_box2[2], test_box2[3],
         )
 
         assert np.isclose(scale.scale2bbox(a, b, c, d)[0], test_box[0], rtol=1e-12)
@@ -68,5 +69,5 @@ def test_custom_scales():
             assert np.isclose(scale.scale2bbox(e, f, g, h)[3], test_box2[3], rtol=1e-12)
         else:
             assert np.isclose(
-                scale.scale2bbox(e, f, g, h)[3], scale.frequencies[0], rtol=1e-12
+                scale.scale2bbox(e, f, g, h)[3], scale.frequencies[0], rtol=1e-12,
             )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 import pytest
 from OSmOSE import Dataset
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -24,7 +24,10 @@ def test_find_or_create_original_folder(input_dataset):
 @pytest.mark.integ
 def test_build(input_dataset):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
+        input_dataset["main_dir"],
+        gps_coordinates=(1, 1),
+        depth=10,
+        timezone="+03:00",
     )
 
     dataset.build()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,7 @@
 import os
+
 import pytest
+
 from OSmOSE import Dataset
 
 
@@ -11,7 +13,7 @@ def test_find_or_create_original_folder(input_dataset):
     assert folder == input_dataset["orig_audio_dir"]
 
     input_dataset["orig_audio_dir"].rename(
-        input_dataset["orig_audio_dir"].with_name("unconventional_name")
+        input_dataset["orig_audio_dir"].with_name("unconventional_name"),
     )
 
     folder2 = dataset._find_or_create_original_folder()
@@ -22,7 +24,7 @@ def test_find_or_create_original_folder(input_dataset):
 @pytest.mark.integ
 def test_build(input_dataset):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00"
+        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
     )
 
     dataset.build()
@@ -39,5 +41,5 @@ def test_build(input_dataset):
             "timestamp.csv",
         ]
         + [f"20220101_1200{str(3*i).zfill(2)}.wav" for i in range(5)]
-        + [f"20220101_1200{str(3*i).zfill(2)}.flac" for i in range(5, 10)]
+        + [f"20220101_1200{str(3*i).zfill(2)}.flac" for i in range(5, 10)],
     )

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from OSmOSE import Job_builder

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,5 +1,6 @@
 
 import pytest
+
 from OSmOSE import Job_builder
 
 custom_config = {
@@ -39,7 +40,7 @@ def test_build_job_file(output_dir):
         logdir=output_dir,
     )
 
-    with open(jb.prepared_jobs[0]["path"], "r") as f:
+    with open(jb.prepared_jobs[0]["path"]) as f:
         text = "".join(f.readlines())
 
     assert pbshead in text

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,5 +1,3 @@
-import os
-from pathlib import Path
 
 import pytest
 from OSmOSE import Job_builder

--- a/tests/test_reshaper.py
+++ b/tests/test_reshaper.py
@@ -48,7 +48,10 @@ def test_reshape_errors(input_dir):
 @pytest.mark.unit
 def test_reshape_smaller(input_dataset: Path, output_dir: Path):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
+        input_dataset["main_dir"],
+        gps_coordinates=(1, 1),
+        depth=10,
+        timezone="+03:00",
     )
     dataset.build()
 
@@ -61,7 +64,8 @@ def test_reshape_smaller(input_dataset: Path, output_dir: Path):
     reshaped_files = [
         output_dir.joinpath(outfile)
         for outfile in pd.read_csv(
-            str(output_dir.joinpath("timestamp_0.csv")), header=0,
+            str(output_dir.joinpath("timestamp_0.csv")),
+            header=0,
         )["filename"].values
     ]
 
@@ -74,7 +78,10 @@ def test_reshape_smaller(input_dataset: Path, output_dir: Path):
 @pytest.mark.unit
 def test_reshape_with_new_sr(input_dataset: Path, output_dir):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
+        input_dataset["main_dir"],
+        gps_coordinates=(1, 1),
+        depth=10,
+        timezone="+03:00",
     )
     dataset.build()
 
@@ -88,7 +95,8 @@ def test_reshape_with_new_sr(input_dataset: Path, output_dir):
     reshaped_files = [
         output_dir.joinpath(outfile)
         for outfile in pd.read_csv(
-            str(output_dir.joinpath("timestamp_0.csv")), header=0,
+            str(output_dir.joinpath("timestamp_0.csv")),
+            header=0,
         )["filename"].values
     ]
 
@@ -101,7 +109,10 @@ def test_reshape_with_new_sr(input_dataset: Path, output_dir):
 @pytest.mark.unit
 def test_reshape_truncate_last(input_dataset: Path, output_dir):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
+        input_dataset["main_dir"],
+        gps_coordinates=(1, 1),
+        depth=10,
+        timezone="+03:00",
     )
     dataset.build()
 
@@ -114,7 +125,8 @@ def test_reshape_truncate_last(input_dataset: Path, output_dir):
     reshaped_files = [
         output_dir.joinpath(outfile)
         for outfile in pd.read_csv(
-            str(output_dir.joinpath("timestamp_0.csv")), header=0,
+            str(output_dir.joinpath("timestamp_0.csv")),
+            header=0,
         )["filename"].values
     ]
 

--- a/tests/test_reshaper.py
+++ b/tests/test_reshaper.py
@@ -1,9 +1,11 @@
 from pathlib import Path
+
 import pandas as pd
-from OSmOSE.cluster.audio_reshaper import reshape
-from OSmOSE import Dataset
 import pytest
 import soundfile as sf
+
+from OSmOSE import Dataset
+from OSmOSE.cluster.audio_reshaper import reshape
 
 
 @pytest.mark.unit
@@ -28,7 +30,7 @@ def test_reshape_errors(input_dir):
 
     assert (
         str(e.value)
-        == f"The input files must be a valid folder path, not '{str(Path('/not/a/path'))}'."
+        == f"The input files must be a valid folder path, not '{Path('/not/a/path')!s}'."
     )
 
     with pytest.raises(FileNotFoundError) as e:
@@ -46,7 +48,7 @@ def test_reshape_errors(input_dir):
 @pytest.mark.unit
 def test_reshape_smaller(input_dataset: Path, output_dir: Path):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00"
+        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
     )
     dataset.build()
 
@@ -59,7 +61,7 @@ def test_reshape_smaller(input_dataset: Path, output_dir: Path):
     reshaped_files = [
         output_dir.joinpath(outfile)
         for outfile in pd.read_csv(
-            str(output_dir.joinpath("timestamp_0.csv")), header=0
+            str(output_dir.joinpath("timestamp_0.csv")), header=0,
         )["filename"].values
     ]
 
@@ -72,7 +74,7 @@ def test_reshape_smaller(input_dataset: Path, output_dir: Path):
 @pytest.mark.unit
 def test_reshape_with_new_sr(input_dataset: Path, output_dir):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00"
+        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
     )
     dataset.build()
 
@@ -86,7 +88,7 @@ def test_reshape_with_new_sr(input_dataset: Path, output_dir):
     reshaped_files = [
         output_dir.joinpath(outfile)
         for outfile in pd.read_csv(
-            str(output_dir.joinpath("timestamp_0.csv")), header=0
+            str(output_dir.joinpath("timestamp_0.csv")), header=0,
         )["filename"].values
     ]
 
@@ -99,7 +101,7 @@ def test_reshape_with_new_sr(input_dataset: Path, output_dir):
 @pytest.mark.unit
 def test_reshape_truncate_last(input_dataset: Path, output_dir):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00"
+        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
     )
     dataset.build()
 
@@ -112,7 +114,7 @@ def test_reshape_truncate_last(input_dataset: Path, output_dir):
     reshaped_files = [
         output_dir.joinpath(outfile)
         for outfile in pd.read_csv(
-            str(output_dir.joinpath("timestamp_0.csv")), header=0
+            str(output_dir.joinpath("timestamp_0.csv")), header=0,
         )["filename"].values
     ]
 

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -1,14 +1,15 @@
 import numpy as np
-from OSmOSE import Spectrogram, Dataset
-from OSmOSE.config import OSMOSE_PATH, SUPPORTED_AUDIO_FORMAT
-import soundfile as sf
 import pytest
+import soundfile as sf
+
+from OSmOSE import Dataset, Spectrogram
+from OSmOSE.config import OSMOSE_PATH, SUPPORTED_AUDIO_FORMAT
 
 
 @pytest.mark.integ
 def test_initialize_2s(input_dataset):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00"
+        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
     )
     dataset.build()
 
@@ -17,8 +18,8 @@ def test_initialize_2s(input_dataset):
     for ext in SUPPORTED_AUDIO_FORMAT:
         num_file += len(
             list(
-                dataset.path.joinpath(OSMOSE_PATH.raw_audio, "3_44100").glob(f"*{ext}")
-            )
+                dataset.path.joinpath(OSMOSE_PATH.raw_audio, "3_44100").glob(f"*{ext}"),
+            ),
         )
     assert num_file == 10
 
@@ -72,7 +73,7 @@ def test_initialize_2s(input_dataset):
 @pytest.mark.integ
 def test_number_image_matrix(input_dataset):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00"
+        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
     )
     dataset.build()
 
@@ -81,8 +82,8 @@ def test_number_image_matrix(input_dataset):
     for ext in SUPPORTED_AUDIO_FORMAT:
         num_file += len(
             list(
-                dataset.path.joinpath(OSMOSE_PATH.raw_audio, "3_44100").glob(f"*{ext}")
-            )
+                dataset.path.joinpath(OSMOSE_PATH.raw_audio, "3_44100").glob(f"*{ext}"),
+            ),
         )
     assert num_file == 10
 
@@ -102,7 +103,7 @@ def test_number_image_matrix(input_dataset):
     list_audio = []
     for ext in SUPPORTED_AUDIO_FORMAT:
         list_audio_ext = spectrogram.path.joinpath(
-            "data", "audio", f"{spectrogram.spectro_duration}_{spectrogram.dataset_sr}"
+            "data", "audio", f"{spectrogram.spectro_duration}_{spectrogram.dataset_sr}",
         ).glob(f"*{ext}")
         [list_audio.append(f) for f in list_audio_ext]
 
@@ -117,8 +118,8 @@ def test_number_image_matrix(input_dataset):
                     f"{spectrogram.spectro_duration}_{spectrogram.dataset_sr}",
                     f"{spectrogram.window_size}_{spectrogram.window_size}_{spectrogram.overlap}_{spectrogram.custom_frequency_scale}",
                     "image",
-                ).glob("*.png")
-            )
+                ).glob("*.png"),
+            ),
         )
     else:
         assert len(list_audio) == len(
@@ -128,8 +129,8 @@ def test_number_image_matrix(input_dataset):
                     f"{spectrogram.spectro_duration}_{spectrogram.dataset_sr}",
                     f"{spectrogram.window_size}_{spectrogram.window_size}_{spectrogram.overlap}_{spectrogram.custom_frequency_scale}",
                     "image",
-                ).glob("*.png")
-            )
+                ).glob("*.png"),
+            ),
         )
 
     for file in list_audio:
@@ -140,7 +141,7 @@ def test_number_image_matrix(input_dataset):
 @pytest.mark.integ
 def test_numerical_values(input_dataset):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00"
+        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
     )
     dataset.build()
 
@@ -161,12 +162,12 @@ def test_numerical_values(input_dataset):
     list_audio = []
     for ext in SUPPORTED_AUDIO_FORMAT:
         list_audio_ext = spectrogram.path.joinpath(
-            "data", "audio", f"{spectrogram.spectro_duration}_{spectrogram.dataset_sr}"
+            "data", "audio", f"{spectrogram.spectro_duration}_{spectrogram.dataset_sr}",
         ).glob(f"*{ext}")
         [list_audio.append(f) for f in list_audio_ext]
 
     spectrogram.process_all_files(
-        list_audio_to_process=list_audio, save_for_LTAS=True, save_matrix=True
+        list_audio_to_process=list_audio, save_for_LTAS=True, save_matrix=True,
     )
 
     # test 3s welch spectra against PamGuide reference values
@@ -434,10 +435,10 @@ def test_numerical_values(input_dataset):
                 5.98928434e-07,
                 1.14932571e-06,
                 2.52971788e-06,
-            ]
-        ]
+            ],
+        ],
     )
 
     assert np.allclose(
-        data["Sxx"], data["Sxx"] + 10 ** (-13)
+        data["Sxx"], data["Sxx"] + 10 ** (-13),
     )  # test not set yet, to be done, work in local but not on github

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -173,7 +173,8 @@ def test_numerical_values(input_dataset):
     list_welch = list((dataset.path / OSMOSE_PATH.welch / "3_44100").glob("*.npz"))
     data = np.load(list_welch[0], allow_pickle=True)
 
-    val_PamGuide = np.array(
+
+    val_PamGuide = np.array(  # noqa: F841
         [
             [
                 3.73173496e02,

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -1,6 +1,3 @@
-import os
-import platform
-import pandas as pd
 import numpy as np
 from OSmOSE import Spectrogram, Dataset
 from OSmOSE.config import OSMOSE_PATH, SUPPORTED_AUDIO_FORMAT
@@ -15,7 +12,7 @@ def test_initialize_2s(input_dataset):
     )
     dataset.build()
 
-    assert dataset.path.joinpath(OSMOSE_PATH.raw_audio, f"3_44100").exists()
+    assert dataset.path.joinpath(OSMOSE_PATH.raw_audio, "3_44100").exists()
     num_file = 0
     for ext in SUPPORTED_AUDIO_FORMAT:
         num_file += len(
@@ -79,7 +76,7 @@ def test_number_image_matrix(input_dataset):
     )
     dataset.build()
 
-    assert dataset.path.joinpath(OSMOSE_PATH.raw_audio, f"3_44100").exists()
+    assert dataset.path.joinpath(OSMOSE_PATH.raw_audio, "3_44100").exists()
     num_file = 0
     for ext in SUPPORTED_AUDIO_FORMAT:
         num_file += len(

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -9,7 +9,10 @@ from OSmOSE.config import OSMOSE_PATH, SUPPORTED_AUDIO_FORMAT
 @pytest.mark.integ
 def test_initialize_2s(input_dataset):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
+        input_dataset["main_dir"],
+        gps_coordinates=(1, 1),
+        depth=10,
+        timezone="+03:00",
     )
     dataset.build()
 
@@ -73,7 +76,10 @@ def test_initialize_2s(input_dataset):
 @pytest.mark.integ
 def test_number_image_matrix(input_dataset):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
+        input_dataset["main_dir"],
+        gps_coordinates=(1, 1),
+        depth=10,
+        timezone="+03:00",
     )
     dataset.build()
 
@@ -103,7 +109,9 @@ def test_number_image_matrix(input_dataset):
     list_audio = []
     for ext in SUPPORTED_AUDIO_FORMAT:
         list_audio_ext = spectrogram.path.joinpath(
-            "data", "audio", f"{spectrogram.spectro_duration}_{spectrogram.dataset_sr}",
+            "data",
+            "audio",
+            f"{spectrogram.spectro_duration}_{spectrogram.dataset_sr}",
         ).glob(f"*{ext}")
         [list_audio.append(f) for f in list_audio_ext]
 
@@ -141,7 +149,10 @@ def test_number_image_matrix(input_dataset):
 @pytest.mark.integ
 def test_numerical_values(input_dataset):
     dataset = Dataset(
-        input_dataset["main_dir"], gps_coordinates=(1, 1), depth=10, timezone="+03:00",
+        input_dataset["main_dir"],
+        gps_coordinates=(1, 1),
+        depth=10,
+        timezone="+03:00",
     )
     dataset.build()
 
@@ -162,18 +173,21 @@ def test_numerical_values(input_dataset):
     list_audio = []
     for ext in SUPPORTED_AUDIO_FORMAT:
         list_audio_ext = spectrogram.path.joinpath(
-            "data", "audio", f"{spectrogram.spectro_duration}_{spectrogram.dataset_sr}",
+            "data",
+            "audio",
+            f"{spectrogram.spectro_duration}_{spectrogram.dataset_sr}",
         ).glob(f"*{ext}")
         [list_audio.append(f) for f in list_audio_ext]
 
     spectrogram.process_all_files(
-        list_audio_to_process=list_audio, save_for_LTAS=True, save_matrix=True,
+        list_audio_to_process=list_audio,
+        save_for_LTAS=True,
+        save_matrix=True,
     )
 
     # test 3s welch spectra against PamGuide reference values
     list_welch = list((dataset.path / OSMOSE_PATH.welch / "3_44100").glob("*.npz"))
     data = np.load(list_welch[0], allow_pickle=True)
-
 
     val_PamGuide = np.array(  # noqa: F841
         [
@@ -440,5 +454,6 @@ def test_numerical_values(input_dataset):
     )
 
     assert np.allclose(
-        data["Sxx"], data["Sxx"] + 10 ** (-13),
+        data["Sxx"],
+        data["Sxx"] + 10 ** (-13),
     )  # test not set yet, to be done, work in local but not on github

--- a/tests/test_timestamp_utils.py
+++ b/tests/test_timestamp_utils.py
@@ -213,7 +213,8 @@ def test_strptime_from_text(text: str, datetime_template: str, expected: Timesta
             "7189.230405144906.wav",
             "%y%m%d%H%M%%S",
             pytest.raises(
-                ValueError, match="%y%m%d%H%M%%S is not a supported strftime template",
+                ValueError,
+                match="%y%m%d%H%M%%S is not a supported strftime template",
             ),
             id="%%_is_wrong_strftime_code",
         ),
@@ -221,7 +222,8 @@ def test_strptime_from_text(text: str, datetime_template: str, expected: Timesta
             "7189.230405144906.wav",
             "%y%m%d%H%M%P%S",
             pytest.raises(
-                ValueError, match="%y%m%d%H%M%P%S is not a supported strftime template",
+                ValueError,
+                match="%y%m%d%H%M%P%S is not a supported strftime template",
             ),
             id="%P_is_wrong_strftime_code",
         ),
@@ -229,7 +231,8 @@ def test_strptime_from_text(text: str, datetime_template: str, expected: Timesta
             "7189.230405144906.wav",
             "%y%m%d%H%M%52%S",
             pytest.raises(
-                ValueError, match="%y%m%d%H%M%52%S is not a supported strftime template",
+                ValueError,
+                match="%y%m%d%H%M%52%S is not a supported strftime template",
             ),
             id="%5_is_wrong_strftime_code",
         ),
@@ -287,7 +290,9 @@ def test_strptime_from_text(text: str, datetime_template: str, expected: Timesta
     ],
 )
 def test_strptime_from_text_errors(
-    text: str, datetime_template: str, expected: Timestamp,
+    text: str,
+    datetime_template: str,
+    expected: Timestamp,
 ):
     with expected as e:
         assert strptime_from_text(text, datetime_template) == e
@@ -335,7 +340,8 @@ def test_associate_timestamps_error_with_incorrect_datetime_format(correct_serie
         match=f"{input_files[0]} did not match the given {mismatching_datetime_format} template",
     ) as e:
         assert e == associate_timestamps(
-            (i for i in input_files), mismatching_datetime_format,
+            (i for i in input_files),
+            mismatching_datetime_format,
         )
 
     with pytest.raises(
@@ -343,7 +349,8 @@ def test_associate_timestamps_error_with_incorrect_datetime_format(correct_serie
         match=f"{incorrect_datetime_format} is not a supported strftime template",
     ):
         assert e == associate_timestamps(
-            (i for i in input_files), incorrect_datetime_format,
+            (i for i in input_files),
+            incorrect_datetime_format,
         )
 
 

--- a/tests/test_timestamp_utils.py
+++ b/tests/test_timestamp_utils.py
@@ -1,12 +1,14 @@
-import pytest
 import pandas as pd
+import pytest
 from pandas import Timestamp
+
 from OSmOSE.utils.timestamp_utils import (
-    is_datetime_template_valid,
-    build_regex_from_datetime_template,
     associate_timestamps,
+    build_regex_from_datetime_template,
+    is_datetime_template_valid,
+    strftime_osmose_format,
     strptime_from_text,
-    strftime_osmose_format)
+)
 
 
 @pytest.mark.unit
@@ -211,7 +213,7 @@ def test_strptime_from_text(text: str, datetime_template: str, expected: Timesta
             "7189.230405144906.wav",
             "%y%m%d%H%M%%S",
             pytest.raises(
-                ValueError, match="%y%m%d%H%M%%S is not a supported strftime template"
+                ValueError, match="%y%m%d%H%M%%S is not a supported strftime template",
             ),
             id="%%_is_wrong_strftime_code",
         ),
@@ -219,7 +221,7 @@ def test_strptime_from_text(text: str, datetime_template: str, expected: Timesta
             "7189.230405144906.wav",
             "%y%m%d%H%M%P%S",
             pytest.raises(
-                ValueError, match="%y%m%d%H%M%P%S is not a supported strftime template"
+                ValueError, match="%y%m%d%H%M%P%S is not a supported strftime template",
             ),
             id="%P_is_wrong_strftime_code",
         ),
@@ -227,7 +229,7 @@ def test_strptime_from_text(text: str, datetime_template: str, expected: Timesta
             "7189.230405144906.wav",
             "%y%m%d%H%M%52%S",
             pytest.raises(
-                ValueError, match="%y%m%d%H%M%52%S is not a supported strftime template"
+                ValueError, match="%y%m%d%H%M%52%S is not a supported strftime template",
             ),
             id="%5_is_wrong_strftime_code",
         ),
@@ -285,7 +287,7 @@ def test_strptime_from_text(text: str, datetime_template: str, expected: Timesta
     ],
 )
 def test_strptime_from_text_errors(
-    text: str, datetime_template: str, expected: Timestamp
+    text: str, datetime_template: str, expected: Timestamp,
 ):
     with expected as e:
         assert strptime_from_text(text, datetime_template) == e
@@ -296,16 +298,16 @@ def correct_series():
     series = pd.Series(
         {
             "something2345_2012_06_24__16:32:10.wav": pd.Timestamp(
-                "2012-06-24 16:32:10"
+                "2012-06-24 16:32:10",
             ),
             "something2345_2023_07_28__08:24:50.flac": pd.Timestamp(
-                "2023-07-28 08:24:50"
+                "2023-07-28 08:24:50",
             ),
             "something2345_2024_01_01__23:12:11.WAV": pd.Timestamp(
-                "2024-01-01 23:12:11"
+                "2024-01-01 23:12:11",
             ),
             "something2345_2024_02_02__02:02:02.FLAC": pd.Timestamp(
-                "2024-02-02 02:02:02"
+                "2024-02-02 02:02:02",
             ),
         },
         name="timestamp",
@@ -318,7 +320,7 @@ def correct_series():
 def test_associate_timestamps(correct_series):
     input_files = list(correct_series["filename"])
     assert associate_timestamps((i for i in input_files), "%Y_%m_%d__%H:%M:%S").equals(
-        correct_series
+        correct_series,
     )
 
 
@@ -333,7 +335,7 @@ def test_associate_timestamps_error_with_incorrect_datetime_format(correct_serie
         match=f"{input_files[0]} did not match the given {mismatching_datetime_format} template",
     ) as e:
         assert e == associate_timestamps(
-            (i for i in input_files), mismatching_datetime_format
+            (i for i in input_files), mismatching_datetime_format,
         )
 
     with pytest.raises(
@@ -341,7 +343,7 @@ def test_associate_timestamps_error_with_incorrect_datetime_format(correct_serie
         match=f"{incorrect_datetime_format} is not a supported strftime template",
     ):
         assert e == associate_timestamps(
-            (i for i in input_files), incorrect_datetime_format
+            (i for i in input_files), incorrect_datetime_format,
         )
 
 

--- a/tests/test_timestamp_utils.py
+++ b/tests/test_timestamp_utils.py
@@ -1,5 +1,12 @@
 import pytest
-from OSmOSE.utils.timestamp_utils import *
+import pandas as pd
+from pandas import Timestamp
+from OSmOSE.utils.timestamp_utils import (
+    is_datetime_template_valid,
+    build_regex_from_datetime_template,
+    associate_timestamps,
+    strptime_from_text,
+    strftime_osmose_format)
 
 
 @pytest.mark.unit

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,7 @@
-from io import StringIO
-import os
 
 import pandas as pd
 import pytest
-import shutil
 from OSmOSE.utils.core_utils import read_header, safe_read
-from OSmOSE.config import OSMOSE_PATH
 import numpy as np
 import soundfile as sf
 from OSmOSE.utils.formatting_utils import aplose2raven

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -17,7 +16,11 @@ def test_safe_read(input_dir):
 
     data = rng.standard_normal(duration * rate)
     sf.write(
-        input_dir.joinpath("nonan.wav"), data, rate, format="WAV", subtype="DOUBLE",
+        input_dir.joinpath("nonan.wav"),
+        data,
+        rate,
+        format="WAV",
+        subtype="DOUBLE",
     )
 
     assert np.array_equal(data, safe_read(input_dir.joinpath("nonan.wav"))[0])
@@ -27,7 +30,11 @@ def test_safe_read(input_dir):
     nandata[0], nandata[137], nandata[2055] = np.nan, np.nan, np.nan
     expected[0], expected[137], expected[2055] = 0.0, 0.0, 0.0
     sf.write(
-        input_dir.joinpath("nan.wav"), nandata, rate, format="WAV", subtype="DOUBLE",
+        input_dir.joinpath("nan.wav"),
+        nandata,
+        rate,
+        format="WAV",
+        subtype="DOUBLE",
     )
 
     assert np.array_equal(expected, safe_read(input_dir.joinpath("nan.wav"))[0])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,10 @@
 
+import numpy as np
 import pandas as pd
 import pytest
-from OSmOSE.utils.core_utils import read_header, safe_read
-import numpy as np
 import soundfile as sf
+
+from OSmOSE.utils.core_utils import read_header, safe_read
 from OSmOSE.utils.formatting_utils import aplose2raven
 
 
@@ -16,7 +17,7 @@ def test_safe_read(input_dir):
 
     data = rng.standard_normal(duration * rate)
     sf.write(
-        input_dir.joinpath("nonan.wav"), data, rate, format="WAV", subtype="DOUBLE"
+        input_dir.joinpath("nonan.wav"), data, rate, format="WAV", subtype="DOUBLE",
     )
 
     assert np.array_equal(data, safe_read(input_dir.joinpath("nonan.wav"))[0])
@@ -26,7 +27,7 @@ def test_safe_read(input_dir):
     nandata[0], nandata[137], nandata[2055] = np.nan, np.nan, np.nan
     expected[0], expected[137], expected[2055] = 0.0, 0.0, 0.0
     sf.write(
-        input_dir.joinpath("nan.wav"), nandata, rate, format="WAV", subtype="DOUBLE"
+        input_dir.joinpath("nan.wav"), nandata, rate, format="WAV", subtype="DOUBLE",
     )
 
     assert np.array_equal(expected, safe_read(input_dir.joinpath("nan.wav"))[0])
@@ -41,7 +42,7 @@ def test_read_header(input_dir):
     size = 529272
 
     assert (sr, frames, sampwidth, channels, size) == read_header(
-        input_dir.joinpath("test.wav")
+        input_dir.joinpath("test.wav"),
     )
 
 
@@ -68,7 +69,7 @@ def aplose_dataframe():
                 pd.Timestamp("2020-05-29T11:32:00.000+00:00"),
             ],
             "is_box": [0, 0, 1],
-        }
+        },
     )
 
     return data.reset_index(drop=True)
@@ -87,7 +88,7 @@ def test_aplose2raven(aplose_dataframe):
             "End Time (s)": [60.0, 120.0, 68.1],
             "Low Freq (Hz)": [0.0, 0.0, 18500.0],
             "High Freq (Hz)": [96000.0, 96000.0, 53000.0],
-        }
+        },
     )
 
     assert expected_raven_dataframe.equals(raven_dataframe)


### PR DESCRIPTION
I did some linting with [Ruff](https://docs.astral.sh/ruff/).

This PR mostly contains stylistic changes, but also removes the **star imports** from the codebase because functions ended up being imported messily. It means that some local usages might have to resolve import issues:

```py
from OSmOSE.utils import get_all_audio_files
```
should be replaced with
```py
from OSmOSE.utils.audio_utils import get_all_audio_files
```

I extensively linted only the code I produced earlier (I let most of the existing code as it is, apart from some things that were either easy to fix or that Ruff automatically resolves) and I will use Ruff from now on on the code I produce.