### PR TITLE
new_file variable and file_metadata selection fix

### DIFF
--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -701,9 +701,9 @@ class Spectrogram(Dataset):
             ].apply(lambda t: pd.Timedelta(seconds=t))
 
             selected_file_metadata = file_metadata[
-                (file_metadata["timestamp"] < pd.Timestamp(datetime_end)) &
-                (file_metadata["end"] > pd.Timestamp(datetime_begin))
-                ]
+                (file_metadata["timestamp"] < pd.Timestamp(datetime_end))
+                & (file_metadata["end"] > pd.Timestamp(datetime_begin))
+            ]
 
             new_file = []
             for i, ts in enumerate(selected_file_metadata["timestamp"]):
@@ -713,11 +713,12 @@ class Spectrogram(Dataset):
                 )
 
                 while current_ts <= ts + original_timedelta:
-                    if (
-                        pd.Timestamp(datetime_begin) < current_ts < pd.Timestamp(datetime_end)
-                        or pd.Timestamp(datetime_begin)
-                        < current_ts + pd.Timedelta(seconds=self.spectro_duration)
-                        < pd.Timestamp(datetime_end)
+                    if pd.Timestamp(datetime_begin) < current_ts < pd.Timestamp(
+                        datetime_end
+                    ) or pd.Timestamp(datetime_begin) < current_ts + pd.Timedelta(
+                        seconds=self.spectro_duration
+                    ) < pd.Timestamp(
+                        datetime_end
                     ):
                         new_file.append(current_ts)
                     current_ts += pd.Timedelta(seconds=self.spectro_duration)

--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -39,7 +39,7 @@ from OSmOSE.utils.path_utils import make_path
 
 
 class Spectrogram(Dataset):
-    """Main class for spectrogram-related computations. Can resample, reshape and normalize audio files before generating spectrograms."""
+    """Main class for spectrogram-related computations. Can resample, reshape audio files before generating spectrograms."""
 
     def __init__(
         self,
@@ -104,7 +104,6 @@ class Spectrogram(Dataset):
         local : `bool`, optional, keyword_only
             Indicates whether or not the program is run locally. If it is the case, it will not create jobs and will handle the paralelisation
             alone. The default is False.
-
         """
         super().__init__(
             dataset_path=dataset_path,
@@ -592,7 +591,6 @@ class Spectrogram(Dataset):
             Force every parameter of the initialization.
         threshold : int, optional
             Integer from 0 to 100 to filter out segments with a number of sample inferior to (threshold * spectrogram duration * segment_sample_rate)
-
         """
         # remove temp directories from adjustment spectrograms
         for path in glob.glob(str(self.path / OSMOSE_PATH.raw_audio / "temp_*")):
@@ -698,13 +696,15 @@ class Spectrogram(Dataset):
                 freq=f"{self.spectro_duration}s",
             ).to_list()[:-1]
         else:
+            file_metadata["end"] = file_metadata["timestamp"] + file_metadata[
+                "duration"
+            ].apply(lambda t: pd.Timedelta(seconds=t))
             selected_file_metadata = file_metadata[
-                (file_metadata["timestamp"] >= datetime_begin)
-                & (file_metadata["timestamp"] <= datetime_end)
+                (file_metadata["timestamp"] < datetime_end)
+                & (file_metadata["end"] > datetime_begin)
             ]
             new_file = []
             for i, ts in enumerate(selected_file_metadata["timestamp"]):
-                counter = 0
                 current_ts = ts
                 original_timedelta = pd.Timedelta(
                     seconds=selected_file_metadata["duration"].iloc[i],
@@ -713,8 +713,6 @@ class Spectrogram(Dataset):
                 while current_ts <= ts + original_timedelta:
                     new_file.append(current_ts)
                     current_ts += pd.Timedelta(seconds=self.spectro_duration)
-                    counter += 1
-            new_file = new_file[: -counter + 1] if counter > 1 else new_file
 
         # size of a batch
         batch_size = len(new_file) // self.batch_number

--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -675,27 +675,17 @@ class Spectrogram(Dataset):
             datetime_begin = (file_metadata["timestamp"].iloc[0]).strftime(
                 "%Y-%m-%dT%H:%M:%S%z",
             )
-        else:
-            try:
-                datetime_begin = pd.Timestamp(datetime_begin)
-            except Exception as e:
-                print(e)
 
         if not datetime_end:
             datetime_end = (
                 file_metadata["timestamp"].iloc[-1]
                 + pd.Timedelta(file_metadata["duration"].iloc[-1], unit="s")
             ).strftime("%Y-%m-%dT%H:%M:%S%z")
-        else:
-            try:
-                datetime_end = pd.Timestamp(datetime_end)
-            except Exception as e:
-                print(e)
 
         # check datetimes
-        if not datetime_begin < datetime_end:
+        if not pd.Timestamp(datetime_begin) < pd.Timestamp(datetime_end):
             raise ValueError(
-                f"'datetime_begin' must be anterior to 'datetime_end'.\ndatetime_begin is set to '{datetime_begin}' and datetime_end is set to '{datetime_end}'",
+                f"'datetime_begin' must be anterior to 'datetime_end'.\ndatetime_begin is set to '{pd.Timestamp(datetime_begin)}' and datetime_end is set to '{pd.Timestamp(datetime_end)}'",
             )
 
         # new timestamps calculation to determine the size of a batch
@@ -709,10 +699,12 @@ class Spectrogram(Dataset):
             file_metadata["end"] = file_metadata["timestamp"] + file_metadata[
                 "duration"
             ].apply(lambda t: pd.Timedelta(seconds=t))
+
             selected_file_metadata = file_metadata[
-                (file_metadata["timestamp"] < datetime_end)
-                & (file_metadata["end"] > datetime_begin)
-            ]
+                (file_metadata["timestamp"] < pd.Timestamp(datetime_end)) &
+                (file_metadata["end"] > pd.Timestamp(datetime_begin))
+                ]
+
             new_file = []
             for i, ts in enumerate(selected_file_metadata["timestamp"]):
                 current_ts = ts
@@ -722,10 +714,10 @@ class Spectrogram(Dataset):
 
                 while current_ts <= ts + original_timedelta:
                     if (
-                        datetime_begin < current_ts < datetime_end
-                        or datetime_begin
+                        pd.Timestamp(datetime_begin) < current_ts < pd.Timestamp(datetime_end)
+                        or pd.Timestamp(datetime_begin)
                         < current_ts + pd.Timedelta(seconds=self.spectro_duration)
-                        < datetime_end
+                        < pd.Timestamp(datetime_end)
                     ):
                         new_file.append(current_ts)
                     current_ts += pd.Timedelta(seconds=self.spectro_duration)

--- a/src/OSmOSE/cluster/audio_reshaper.py
+++ b/src/OSmOSE/cluster/audio_reshaper.py
@@ -170,12 +170,22 @@ def reshape(
     # datetimes
     if not datetime_begin:
         datetime_begin = file_metadata["timestamp"].iloc[0]
+    else:
+        try:
+            datetime_begin = pd.Timestamp(datetime_begin)
+        except Exception as e:
+            print(e)
 
     if not datetime_end:
         datetime_end = file_metadata["timestamp"].iloc[-1] + pd.Timedelta(
             file_metadata["duration"].iloc[-1],
             unit="s",
         )
+    else:
+        try:
+            datetime_end = pd.Timestamp(datetime_end)
+        except Exception as e:
+            print(e)
 
     # segment timestamps
     if concat:
@@ -188,10 +198,12 @@ def reshape(
         file_metadata["end"] = file_metadata["timestamp"] + file_metadata[
             "duration"
         ].apply(lambda t: pd.Timedelta(seconds=t))
+
         origin_timestamp = file_metadata[
             (file_metadata["timestamp"] < datetime_end)
             & (file_metadata["end"] > datetime_begin)
         ]
+
         new_file = []
         for i, ts in enumerate(origin_timestamp["timestamp"]):
             current_ts = ts

--- a/src/OSmOSE/cluster/audio_reshaper.py
+++ b/src/OSmOSE/cluster/audio_reshaper.py
@@ -200,7 +200,11 @@ def reshape(
             )
 
             while current_ts <= ts + original_timedelta:
-                new_file.append(current_ts)
+                if (
+                    datetime_begin < current_ts < datetime_end
+                    or datetime_begin < current_ts + segment_duration < datetime_end
+                ):
+                    new_file.append(current_ts)
                 current_ts += segment_duration
 
     if batch_ind_max == -1:


### PR DESCRIPTION
I modified the way the segments timestamp list `new_file` is created in the case where `dataset.concat = False` both in `Spectrogram.py` and in `audio_reshaper.py`