### PR TITLE
remove duplicate datasets from datasets.csv during aplose export

### DIFF
--- a/src/OSmOSE/utils/core_utils.py
+++ b/src/OSmOSE/utils/core_utils.py
@@ -794,7 +794,11 @@ def add_entry_for_APLOSE(path: str, file: str, info: pd.DataFrame):
 
     if dataset_csv.exists():
         meta = pd.read_csv(dataset_csv)
-        meta = pd.concat([meta, info], ignore_index=True).sort_values(
+        info.path = info.path.map(str)
+        meta = pd.concat(
+            [meta[meta.path != str(info.iloc[0].path)], info], ignore_index=True
+        )
+        meta = meta.sort_values(
             by=["path", "dataset"],
             ascending=True,
         )


### PR DESCRIPTION
The changes in this PR make sure all previous entries in `/home/datawork-osmose/dataset/datasets.csv` that share the same path/name than the dataset from which spectrograms are generated are removed before updating the dataframe.

However, I'm not sure to understand something:

The `datasets.csv` has `spectro_duration` and `dataset_sr` columns: Is this supposed to keep track of the **original** audio only? Let's say I have 14 days of original audio with 2h-long files at 144 kHz, and I want to plot some spectrograms of the 1st hour at 500 Hz with 1min-long audio files: is this a **new** dataset? Or an update of the previous one? Or something that shouldn't even be added in the `datasets.csv` file?
Since the entries are added to this file when `generate_spectro` is called (not when `Dataset.build()` is called), I'm a bit lost.

The current PR only watch for the dataset **path**, so in the previous scenario, the dataset entry in `datasets.csv` would be **updated** to a 1min-500Hz dataset.