### PR TITLE
aplose2raven and test revision

### DIFF
--- a/src/OSmOSE/utils/formatting_utils.py
+++ b/src/OSmOSE/utils/formatting_utils.py
@@ -32,7 +32,7 @@ def aplose2raven(
         list of tz-aware timestamps from considered audio files.
 
     audio_durations: list[float]
-        list of all considered audio file durations.
+        list of all considered audio file durations in seconds.
 
     Returns
     -------
@@ -85,9 +85,8 @@ def aplose2raven(
 
     raven_result = pd.DataFrame()
     raven_result["Selection"] = list(range(1, len(aplose_result) + 1))
-    raven_result["View"], raven_result["Channel"] = [1] * len(aplose_result), [1] * len(
-        aplose_result
-    )
+    raven_result["View"] = [1] * len(aplose_result)
+    raven_result["Channel"] = [1] * len(aplose_result)
     raven_result["Begin Time (s)"] = begin_time_adjusted
     raven_result["End Time (s)"] = end_time_adjusted
     raven_result["Low Freq (Hz)"] = aplose_result["start_frequency"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,9 +82,31 @@ def aplose_dataframe():
     return data.reset_index(drop=True)
 
 
+@pytest.fixture
+def raven_timestamps():
+    audio_ts = list(
+        pd.date_range(
+            start="2020-05-29T11:30:00.000+00:00",
+            end="2020-05-29T11:35:00.000+00:00",
+            freq="1min",
+        )
+    )
+    return audio_ts
+
+
+@pytest.fixture
+def raven_durations(raven_timestamps):
+    audio_dur = [60] * len(raven_timestamps)
+    return audio_dur
+
+
 @pytest.mark.unit
-def test_aplose2raven(aplose_dataframe):
-    raven_dataframe = aplose2raven(df=aplose_dataframe)
+def test_aplose2raven(aplose_dataframe, raven_timestamps, raven_durations):
+    raven_dataframe = aplose2raven(
+        df=aplose_dataframe,
+        audio_datetimes=raven_timestamps,
+        audio_durations=raven_durations,
+    )
 
     expected_raven_dataframe = pd.DataFrame(
         {
@@ -92,7 +114,7 @@ def test_aplose2raven(aplose_dataframe):
             "View": [1, 1, 1],
             "Channel": [1, 1, 1],
             "Begin Time (s)": [0.0, 60.0, 65.9],
-            "End Time (s)": [60.0, 120.0, 68.1],
+            "End Time (s)": [60.0, 120.0, 128.1],
             "Low Freq (Hz)": [0.0, 0.0, 18500.0],
             "High Freq (Hz)": [96000.0, 96000.0, 53000.0],
         },


### PR DESCRIPTION
I have moved the MATLAB snippet that would write Raven tables to python for convenience
This function now take into account the tiny offsets accumulating along the audio files read in Raven due to the fact that there is a difference between the actual duration of an audio file and the annonced duration from the datetimes parsed using the filenames.

This issue comes from the fact that the sample rate of an instrument is not fixed in time (see [this thread](https://bioacoustics.stackexchange.com/questions/1765/how-do-you-take-into-account-soundtrap-offset))