### PR TITLE
[DRAFT] Feature/public api

### DIFF
--- a/src/OSmOSE/core_api/audio_dataset.py
+++ b/src/OSmOSE/core_api/audio_dataset.py
@@ -7,9 +7,7 @@ that simplify repeated operations on the audio data.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
-
-import pytz
+from typing import TYPE_CHECKING, Literal
 
 from OSmOSE.core_api.audio_data import AudioData
 from OSmOSE.core_api.audio_file import AudioFile
@@ -20,6 +18,7 @@ if TYPE_CHECKING:
 
     from pathlib import Path
 
+    import pytz
     from pandas import Timedelta, Timestamp
 
 
@@ -99,6 +98,7 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
         begin: Timestamp | None = None,
         end: Timestamp | None = None,
         timezone: str | pytz.timezone | None = None,
+        bound: Literal["files", "timedelta"] = "timedelta",
         data_duration: Timedelta | None = None,
         **kwargs: any,
     ) -> AudioDataset:
@@ -122,8 +122,14 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
             If different from a timezone parsed from the filename, the timestamps'
             timezone will be converted from the parsed timezone
             to the specified timezone.
+        bound: Literal["files", "timedelta"]
+            Bound between the original files and the dataset data.
+            "files": one data will be created for each file.
+            "timedelta": data objects of duration equal to data_duration will
+            be created.
         data_duration: Timedelta | None
             Duration of the audio data objects.
+            If bound is set to "files", this parameter has no effect.
             If provided, audio data will be evenly distributed between begin and end.
             Else, one data object will cover the whole time period.
         kwargs: any
@@ -144,6 +150,7 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
             begin=begin,
             end=end,
             timezone=timezone,
+            bound=bound,
             data_duration=data_duration,
             **kwargs,
         )
@@ -155,6 +162,7 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
         files: list[AudioFile],
         begin: Timestamp | None = None,
         end: Timestamp | None = None,
+        bound: Literal["files", "timedelta"] = "timedelta",
         data_duration: Timedelta | None = None,
     ) -> AudioDataset:
         """Return an AudioDataset object from a list of AudioFiles.
@@ -169,8 +177,14 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
         end: Timestamp | None
             End of the last data object.
             Defaulted to the end of the last file.
+        bound: Literal["files", "timedelta"]
+            Bound between the original files and the dataset data.
+            "files": one data will be created for each file.
+            "timedelta": data objects of duration equal to data_duration will
+            be created.
         data_duration: Timedelta | None
             Duration of the data objects.
+            If bound is set to "files", this parameter has no effect.
             If provided, data will be evenly distributed between begin and end.
             Else, one data object will cover the whole time period.
 
@@ -180,7 +194,7 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
         The DataBase object.
 
         """
-        base = BaseDataset.from_files(files, begin, end, data_duration)
+        base = BaseDataset.from_files(files, begin, end, bound, data_duration)
         return cls.from_base_dataset(base)
 
     @classmethod

--- a/src/OSmOSE/core_api/audio_file.py
+++ b/src/OSmOSE/core_api/audio_file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -100,3 +101,7 @@ class AudioFile(BaseFile):
     def from_base_file(cls, file: BaseFile) -> AudioFile:
         """Return an AudioFile object from a BaseFile object."""
         return cls(path=file.path, begin=file.begin)
+
+    def move(self, destination_folder: Path):
+        afm.close()
+        super().move(destination_folder)

--- a/src/OSmOSE/core_api/audio_file_manager.py
+++ b/src/OSmOSE/core_api/audio_file_manager.py
@@ -22,7 +22,8 @@ class AudioFileManager:
         """Initialize an audio file manager."""
         self.opened_file = None
 
-    def _close(self) -> None:
+    def close(self) -> None:
+        """Close the currently opened file."""
         if self.opened_file is None:
             return
         self.opened_file.close()
@@ -36,7 +37,7 @@ class AudioFileManager:
             self._open(path)
         if self.opened_file.name == str(path):
             return
-        self._close()
+        self.close()
         self._open(path)
 
     def read(

--- a/src/OSmOSE/core_api/base_data.py
+++ b/src/OSmOSE/core_api/base_data.py
@@ -56,13 +56,43 @@ class BaseData(Generic[TItem, TFile], Event):
         if not items:
             items = [BaseItem(begin=begin, end=end)]
         self.items = items
-        self.begin = min(item.begin for item in self.items)
-        self.end = max(item.end for item in self.items)
+        self._begin = min(item.begin for item in self.items)
+        self._end = max(item.end for item in self.items)
 
     @property
     def is_empty(self) -> bool:
         """Return true if every item of this data object is empty."""
         return all(item.is_empty for item in self.items)
+
+    @property
+    def begin(self) -> Timestamp:
+        """Return the begin timestamp of the data."""
+        return min(item.begin for item in self.items)
+
+    @begin.setter
+    def begin(self, value: Timestamp) -> None:
+        """Trim the beginning of the data.
+
+        Begin can only be set to a posterior date from the original begin.
+
+        """
+        for item in self.items:
+            item.begin = max(item.begin, value)
+
+    @property
+    def end(self) -> Timestamp:
+        """Trim the end timestamp of the data.
+
+        End can only be set to an anterior date from the original end.
+
+        """
+        return max(item.end for item in self.items)
+
+    @end.setter
+    def end(self, value: Timestamp) -> None:
+        """Return true if every item of this data object is empty."""
+        for item in self.items:
+            item.end = min(item.end, value)
 
     def get_value(self) -> np.ndarray:
         """Get the concatenated values from all Items."""

--- a/src/OSmOSE/core_api/base_dataset.py
+++ b/src/OSmOSE/core_api/base_dataset.py
@@ -166,6 +166,7 @@ class BaseDataset(Generic[TData, TFile], Event):
         """
         if bound == "files":
             data_base = [BaseData.from_files([f]) for f in files]
+            data_base = BaseData.remove_overlaps(data_base)
             return cls(data_base)
 
         if not begin:

--- a/src/OSmOSE/core_api/base_dataset.py
+++ b/src/OSmOSE/core_api/base_dataset.py
@@ -170,6 +170,15 @@ class BaseDataset(Generic[TData, TFile], Event):
         return cls(data_base)
 
     def move(self, destination_folder: Path) -> None:
+        """Move the dataset to the specified destination folder.
+
+        Parameters
+        ----------
+        destination_folder: Path
+            The folder in which the dataset will be moved.
+            It will be created if it does not exist.
+
+        """
         for file in self.files:
             file.move(destination_folder)
 

--- a/src/OSmOSE/core_api/base_dataset.py
+++ b/src/OSmOSE/core_api/base_dataset.py
@@ -157,3 +157,7 @@ class BaseDataset(Generic[TData, TFile], Event):
         else:
             data_base = [BaseData.from_files(files, begin=begin, end=end)]
         return cls(data_base)
+
+    def move(self, destination_folder: Path) -> None:
+        for file in self.files:
+            file.move(destination_folder)

--- a/src/OSmOSE/core_api/base_dataset.py
+++ b/src/OSmOSE/core_api/base_dataset.py
@@ -53,6 +53,14 @@ class BaseDataset(Generic[TData, TFile], Event):
         """All files referred to by the Dataset."""
         return {file for data in self.data for file in data.files}
 
+    @property
+    def data_duration(self) -> set[Timedelta] | Timedelta:
+        """Return the sample rate of the audio data."""
+        data_duration = {Timedelta(data.duration) for data in self.data}
+        return (
+            data_duration if len(list(data_duration)) > 1 else next(iter(data_duration))
+        )
+
     def write(self, folder: Path) -> None:
         """Write all data objects in the specified folder.
 

--- a/src/OSmOSE/core_api/base_file.py
+++ b/src/OSmOSE/core_api/base_file.py
@@ -111,3 +111,9 @@ class BaseFile(Event):
     def __str__(self) -> str:
         """Overwrite __str__."""
         return self.begin.strftime(TIMESTAMP_FORMAT_EXPORTED_FILES)
+
+    def move(self, destination_folder: Path):
+        destination_path = destination_folder / self.path.name
+        destination_folder.mkdir(exist_ok=True, parents=True)
+        self.path.rename(destination_path)
+        self.path = destination_path

--- a/src/OSmOSE/core_api/spectro_dataset.py
+++ b/src/OSmOSE/core_api/spectro_dataset.py
@@ -6,10 +6,9 @@ that simplify repeated operations on the spectro data.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
-import pytz
 from scipy.signal import ShortTimeFFT
 
 from OSmOSE.core_api.base_dataset import BaseDataset
@@ -20,6 +19,7 @@ from OSmOSE.core_api.spectro_file import SpectroFile
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytz
     from pandas import Timedelta, Timestamp
 
     from OSmOSE.core_api.audio_dataset import AudioDataset
@@ -131,13 +131,14 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         return cls(sd)
 
     @classmethod
-    def from_folder(
+    def from_folder(  # noqa: PLR0913
         cls,
         folder: Path,
         strptime_format: str,
         begin: Timestamp | None = None,
         end: Timestamp | None = None,
         timezone: str | pytz.timezone | None = None,
+        bound: Literal["files", "timedelta"] = "timedelta",
         data_duration: Timedelta | None = None,
         **kwargs: any,
     ) -> SpectroDataset:
@@ -161,8 +162,14 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             If different from a timezone parsed from the filename, the timestamps'
             timezone will be converted from the parsed timezone
             to the specified timezone.
+        bound: Literal["files", "timedelta"]
+            Bound between the original files and the dataset data.
+            "files": one data will be created for each file.
+            "timedelta": data objects of duration equal to data_duration will
+            be created.
         data_duration: Timedelta | None
             Duration of the spectro data objects.
+            If bound is set to "files", this parameter has no effect.
             If provided, spectro data will be evenly distributed between begin and end.
             Else, one data object will cover the whole time period.
         kwargs: any

--- a/src/OSmOSE/public_api/dataset.py
+++ b/src/OSmOSE/public_api/dataset.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import TypeVar
+
+from OSmOSE.core_api.audio_dataset import AudioDataset
+from OSmOSE.core_api.spectro_dataset import SpectroDataset
+
+
+class Dataset:
+    def __init__(
+        self,
+        folder: Path,
+        strptime_format: str,
+        gps_coordinates: str | list | tuple = (0, 0),
+        depth: str | int = 0,
+        timezone: str | None = None,
+    ):
+        self.folder = folder
+        self.strptime_format = strptime_format
+        self.gps_coordinates = gps_coordinates
+        self.depth = depth
+        self.timezone = timezone
+        self.dataset = {}
+
+    def build(self):
+        ads = AudioDataset.from_folder(
+            self.folder,
+            strptime_format=self.strptime_format,
+        )
+        self.dataset["original"] = ads
+        self._sort_data(self.dataset["original"])
+
+    def restore(self):
+        files_to_remove = list(self.folder.iterdir())
+        self.dataset["original"].move(self.folder)
+        for file in files_to_remove:
+            shutil.rmtree(file)
+
+    def _sort_data(self, dataset: type[DatasetChild]):
+        if type(dataset) is AudioDataset:
+            self._sort_audio_data(dataset)
+            return
+        if type(dataset) is SpectroDataset:
+            self._sort_spectro_data(dataset)
+            return
+
+    def _sort_audio_data(self, data: AudioDataset):
+        data_duration = data.data_duration
+        sample_rate = data.sample_rate
+        data_duration, sample_rate = (parameter if type(parameter) is not set else next(iter(parameter)) for parameter in (data_duration, sample_rate))
+        data.move(
+            self.folder
+            / "data"
+            / "audio"
+            / f"{round(data_duration.total_seconds())}_{round(sample_rate)}",
+        )
+
+
+
+DatasetChild = TypeVar("DatasetChild", bound=Dataset)

--- a/src/OSmOSE/public_api/dataset.py
+++ b/src/OSmOSE/public_api/dataset.py
@@ -49,14 +49,16 @@ class Dataset:
     def _sort_audio_data(self, data: AudioDataset):
         data_duration = data.data_duration
         sample_rate = data.sample_rate
-        data_duration, sample_rate = (parameter if type(parameter) is not set else next(iter(parameter)) for parameter in (data_duration, sample_rate))
+        data_duration, sample_rate = (
+            parameter if type(parameter) is not set else next(iter(parameter))
+            for parameter in (data_duration, sample_rate)
+        )
         data.move(
             self.folder
             / "data"
             / "audio"
             / f"{round(data_duration.total_seconds())}_{round(sample_rate)}",
         )
-
 
 
 DatasetChild = TypeVar("DatasetChild", bound=Dataset)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -673,7 +673,9 @@ def test_audio_resample_sample_count(
             "files",
             None,
             generate_sample_audio(
-                nb_files=3, nb_samples=48_000, series_type="increase"
+                nb_files=3,
+                nb_samples=48_000,
+                series_type="increase",
             ),
             id="files_bound_without_overlap",
         ),
@@ -709,7 +711,11 @@ def test_audio_resample_sample_count(
             None,
             "files",
             None,
-            generate_sample_audio(nb_files=2, nb_samples=48_000),
+            [
+                generate_sample_audio(nb_files=1, nb_samples=48_000)[0][0:24_000],
+                generate_sample_audio(nb_files=1, nb_samples=48_000)[0][0:24_000],
+                generate_sample_audio(nb_files=1, nb_samples=48_000)[0],
+            ],
             id="files_bound_with_overlap",
         ),
     ],
@@ -732,10 +738,9 @@ def test_audio_dataset_from_folder(
         bound=bound,
         data_duration=duration,
     )
-    assert all(
-        np.array_equal(data.get_value(), expected)
-        for (data, expected) in zip(dataset.data, expected_audio_data)
-    )
+    for idx, data in enumerate(dataset.data):
+        vs = data.get_value()
+        assert np.array_equal(expected_audio_data[idx], vs)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_audio_file_manager.py
+++ b/tests/test_audio_file_manager.py
@@ -221,7 +221,7 @@ def test_close(audio_files: tuple[list[Path], pytest.fixtures.Subrequest]) -> No
     afm.read(audio_files[0])
     assert afm.opened_file is not None
     assert Path(afm.opened_file.name) == audio_files[0]
-    afm._close()
+    afm.close()
     assert afm.opened_file is None
 
 

--- a/tests/test_core_api_base.py
+++ b/tests/test_core_api_base.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pandas import Timestamp
+
+from OSmOSE.core_api.base_file import BaseFile
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize(
+    "destination_folder",
+    [
+        pytest.param(
+            "cool",
+            id="moving_to_new_folder",
+        ),
+        pytest.param(
+            "",
+            id="moving_to_same_folder",
+        ),
+    ],
+)
+def test_move_file(
+    tmp_path: Path,
+    destination_folder: str,
+) -> None:
+    filename = "cool.txt"
+    (tmp_path / filename).touch(mode=0o666, exist_ok=True)
+    bf = BaseFile(
+        tmp_path / filename,
+        begin=Timestamp("2022-04-22 12:12:12"),
+        end=Timestamp("2022-04-22 12:13:12"),
+    )
+
+    bf.move(tmp_path / destination_folder)
+
+    assert (tmp_path / destination_folder / filename).exists()
+
+    if destination_folder:
+        assert not (tmp_path / filename).exists()


### PR DESCRIPTION
# PUBLIC API

## Goal

This API aims at providing the user with classes that have a larger scope than those of the Core API. It should look like an updated, easier-to-use/maintain/improve version fo the Legacy OSEkit API.

## The `Dataset` class

This is the keystone class of the API. It is inspired by the [legacy Dataset class](https://github.com/Project-OSmOSE/OSEkit/blob/main/src/OSmOSE/Dataset.py), with some similarities (🟢) and deviations (🔴) from this original version:

- 🟢 It is built thanks to a `Dataset.build` method to organize the audio data in a similar fashion than in the legacy version, maintaining the compatibility with Aplose.
- 🟢 It includes metadata along with the audio/spectro data.
- 🟢 It provides the user with high-level methods performing a series of operations on the data.
- 🟢 It gathers different audio datasets (original, reshaped...), spectrogram and auxiliary datasets
- 🔴 It doesn't correspond to a specific data collection as it did in the legacy version (it still has a reference to the **original** audio dataset tho): this should clarify what **is** a dataset in the OSEkit ecosystem.
- 🔴 It does not rely on another large class like the legacy `Spectrogram`.
- 🔴 It relies on the `Core API`: each audio/spectro dataset that is included in a `Public API Dataset` is an instance of a Core API `AudioDataset` or `SpectroDataset`, respectively
- 🔴 It relies on serialized Core API objects rather than on raw csv files, mutualizing:
    - A simplification of the remote workflow (datasets can be serialized from a jupyter notebook on a server, and deserialized on a new server thanks to a simple job file)
    - A tighter bound between the exported files (that would be parsed in Aplose for example) and the API classes

## Remote workflow

This API also aims at replacing the [datarmor-toolkit utilities](https://github.com/Project-OSmOSE/datarmor-toolkit/tree/main/src): having the code split up between these two repos is quite error-prone, and everything that was previously done using the toolkit should be doable in a simpler way in this API.