### PR TITLE
[Optimization] Event overlap

### DIFF
--- a/src/OSmOSE/core_api/event.py
+++ b/src/OSmOSE/core_api/event.py
@@ -69,7 +69,9 @@ class Event:
         """
         output = []
         start_index = bisect.bisect_left(
-            events, self.begin, key=lambda event: event.begin
+            events,
+            self.begin,
+            key=lambda event: event.end,
         )
         for i in range(start_index, len(events)):
             if events[i] is self:
@@ -77,7 +79,8 @@ class Event:
             if self.overlaps(events[i]):
                 output.append(events[i])
                 continue
-            break
+            if events[i].begin >= self.end:
+                break
         return output
 
     @classmethod


### PR DESCRIPTION
The `OSmOSE.core_api.Event.remove_overlaps()` method's behaviour used an unoptimized way of filtering the list of events to isolate those which overlap with a given event.

This PR fixes this issue by introducing the `Event.get_overlapping_events()` method, which makes use of `bisect.bisect_left()` for finding the index of the first Event in the (sorted) event list to consider, and which returns as soon as we reach an Event in the (sorted) list of events that begins after the current event end.

This decreases build time significantly: on a very large dataset (~25k files), it went from ~20min+ to a couple minutes.