### PR TITLE
[FEATURE] resample quality setting

### DIFF
--- a/src/OSmOSE/config.py
+++ b/src/OSmOSE/config.py
@@ -54,7 +54,7 @@ BUILD_DURATION_DELTA_THRESHOLD = 0.05
 
 FileName: TypeAlias = str | bytes | os.PathLike
 
-resample_quality_setting = {
+resample_quality_settings = {
     "downsample": "QQ",
     "upsample": "MQ",
 }

--- a/src/OSmOSE/config.py
+++ b/src/OSmOSE/config.py
@@ -53,3 +53,8 @@ print_logger = logging.getLogger("printer")
 BUILD_DURATION_DELTA_THRESHOLD = 0.05
 
 FileName: TypeAlias = str | bytes | os.PathLike
+
+resample_quality_setting = {
+    "downsample": "QQ",
+    "upsample": "MQ",
+}

--- a/src/OSmOSE/utils/audio_utils.py
+++ b/src/OSmOSE/utils/audio_utils.py
@@ -12,7 +12,7 @@ from OSmOSE.config import (
     AUDIO_METADATA,
     BUILD_DURATION_DELTA_THRESHOLD,
     SUPPORTED_AUDIO_FORMAT,
-    resample_quality_setting,
+    resample_quality_settings,
 )
 
 
@@ -205,8 +205,8 @@ def resample(data: np.ndarray, origin_sr: float, target_sr: float) -> np.ndarray
 
     """
     quality = (
-        resample_quality_setting["upsample"]
+        resample_quality_settings["upsample"]
         if target_sr > origin_sr
-        else resample_quality_setting["downsample"]
+        else resample_quality_settings["downsample"]
     )
     return soxr.resample(data, origin_sr, target_sr, quality=quality)

--- a/src/OSmOSE/utils/audio_utils.py
+++ b/src/OSmOSE/utils/audio_utils.py
@@ -12,6 +12,7 @@ from OSmOSE.config import (
     AUDIO_METADATA,
     BUILD_DURATION_DELTA_THRESHOLD,
     SUPPORTED_AUDIO_FORMAT,
+    resample_quality_setting,
 )
 
 
@@ -203,4 +204,9 @@ def resample(data: np.ndarray, origin_sr: float, target_sr: float) -> np.ndarray
         The resampled audio data.
 
     """
-    return soxr.resample(data, origin_sr, target_sr, quality="QQ")
+    quality = (
+        resample_quality_setting["upsample"]
+        if target_sr > origin_sr
+        else resample_quality_setting["downsample"]
+    )
+    return soxr.resample(data, origin_sr, target_sr, quality=quality)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import logging
 from typing import TYPE_CHECKING
 
@@ -8,11 +9,13 @@ import pandas as pd
 import pytest
 import soundfile as sf
 
-from OSmOSE.config import TIMESTAMP_FORMAT_TEST_FILES
+import OSmOSE
+from OSmOSE.config import TIMESTAMP_FORMAT_TEST_FILES, resample_quality_setting
 from OSmOSE.core_api.audio_data import AudioData
 from OSmOSE.core_api.audio_dataset import AudioDataset
 from OSmOSE.core_api.audio_file import AudioFile
 from OSmOSE.core_api.audio_item import AudioItem
+from OSmOSE.utils import audio_utils
 from OSmOSE.utils.audio_utils import generate_sample_audio
 
 if TYPE_CHECKING:
@@ -580,6 +583,114 @@ def test_audio_resample_sample_count(
     data = AudioData.from_files(audio_files, begin=start, end=stop)
     data.sample_rate = sample_rate
     assert data.get_value().shape[0] == expected_nb_samples
+
+
+@pytest.mark.parametrize(
+    ("audio_files", "downsampling_quality", "upsampling_quality"),
+    [
+        pytest.param(
+            {
+                "duration": 1,
+                "sample_rate": 48_000,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+                "series_type": "increase",
+            },
+            None,
+            None,
+            id="default_qualities",
+        ),
+        pytest.param(
+            {
+                "duration": 1,
+                "sample_rate": 48_000,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+                "series_type": "increase",
+            },
+            "HQ",
+            None,
+            id="downsample_quality_to_HQ",
+        ),
+        pytest.param(
+            {
+                "duration": 1,
+                "sample_rate": 48_000,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+                "series_type": "increase",
+            },
+            None,
+            "QQ",
+            id="upsample_quality_to_QQ",
+        ),
+        pytest.param(
+            {
+                "duration": 1,
+                "sample_rate": 48_000,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+                "series_type": "increase",
+            },
+            "VHQ",
+            "VHQ",
+            id="both_qualities_to_VHQ",
+        ),
+    ],
+    indirect=["audio_files"],
+)
+def test_audio_resample_quality(
+    audio_files: pytest.fixture,
+    monkeypatch: pytest.MonkeyPatch,
+    downsampling_quality: str | None,
+    upsampling_quality: str | None,
+) -> None:
+    importlib.reload(OSmOSE.config)
+
+    files, _ = audio_files
+    af = AudioFile(files[0], strptime_format=TIMESTAMP_FORMAT_TEST_FILES)
+
+    downsampling_default = resample_quality_setting["downsample"]
+    upsampling_default = resample_quality_setting["upsample"]
+
+    if downsampling_quality is not None:
+        OSmOSE.config.resample_quality_setting["downsample"] = downsampling_quality
+    if upsampling_quality is not None:
+        OSmOSE.config.resample_quality_setting["upsample"] = upsampling_quality
+
+    def resample_mkptch(
+        data: np.ndarray,
+        origin_sr: float,
+        target_sr: float,
+    ) -> np.ndarray:
+        return (
+            OSmOSE.config.resample_quality_setting["upsample"]
+            if target_sr > origin_sr
+            else OSmOSE.config.resample_quality_setting["downsample"]
+        )
+
+    monkeypatch.setattr(audio_utils, "resample", resample_mkptch)
+
+    ad = AudioData.from_files([af])
+
+    downsampling_frequency, upsampling_frequency = (
+        ratio * ad.sample_rate for ratio in (0.5, 1.5)
+    )
+
+    assert audio_utils.resample(
+        ad.get_value(),
+        ad.sample_rate,
+        downsampling_frequency,
+    ) == (
+        downsampling_quality
+        if downsampling_quality is not None
+        else downsampling_default
+    )
+    assert audio_utils.resample(
+        ad.get_value(),
+        ad.sample_rate,
+        upsampling_frequency,
+    ) == (upsampling_quality if upsampling_quality is not None else upsampling_default)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -10,7 +10,7 @@ import pytest
 import soundfile as sf
 
 import OSmOSE
-from OSmOSE.config import TIMESTAMP_FORMAT_TEST_FILES, resample_quality_setting
+from OSmOSE.config import TIMESTAMP_FORMAT_TEST_FILES, resample_quality_settings
 from OSmOSE.core_api.audio_data import AudioData
 from OSmOSE.core_api.audio_dataset import AudioDataset
 from OSmOSE.core_api.audio_file import AudioFile
@@ -650,13 +650,13 @@ def test_audio_resample_quality(
     files, _ = audio_files
     af = AudioFile(files[0], strptime_format=TIMESTAMP_FORMAT_TEST_FILES)
 
-    downsampling_default = resample_quality_setting["downsample"]
-    upsampling_default = resample_quality_setting["upsample"]
+    downsampling_default = resample_quality_settings["downsample"]
+    upsampling_default = resample_quality_settings["upsample"]
 
     if downsampling_quality is not None:
-        OSmOSE.config.resample_quality_setting["downsample"] = downsampling_quality
+        OSmOSE.config.resample_quality_settings["downsample"] = downsampling_quality
     if upsampling_quality is not None:
-        OSmOSE.config.resample_quality_setting["upsample"] = upsampling_quality
+        OSmOSE.config.resample_quality_settings["upsample"] = upsampling_quality
 
     def resample_mkptch(
         data: np.ndarray,
@@ -664,9 +664,9 @@ def test_audio_resample_quality(
         target_sr: float,
     ) -> np.ndarray:
         return (
-            OSmOSE.config.resample_quality_setting["upsample"]
+            OSmOSE.config.resample_quality_settings["upsample"]
             if target_sr > origin_sr
-            else OSmOSE.config.resample_quality_setting["downsample"]
+            else OSmOSE.config.resample_quality_settings["downsample"]
         )
 
     monkeypatch.setattr(audio_utils, "resample", resample_mkptch)


### PR DESCRIPTION
This PR adds a `resample_quality_setting` dictionary to the `OSmOSE.config` module:

```py
resample_quality_settings = {
    "downsample": "QQ",
    "upsample": "MQ",
}
```

The settings are related to the [soxr resample quality parameters](https://python-soxr.readthedocs.io/en/latest/soxr.html#soxr.resample).

`"QQ"` and `"MQ"` have been chosen for default downsampling and upsampling qualities, respectively,  as `"QQ"` seems to avoid darker areas in the highest-frequency domain of spectrograms and as `"MQ"` avoids most artifacts in the upsampled frequency range of spectrograms:

| Quality | Downsampling | Upsampling |
|:---|:---:|:---:|
|`"QQ"`|![image](https://github.com/user-attachments/assets/aebe892f-0207-4b28-a2fb-a8fe41ceec4e)|![image](https://github.com/user-attachments/assets/f0f88ab5-287e-4f4b-afd8-3a34aa47ef40)|
|`"MQ"`|![image](https://github.com/user-attachments/assets/0252d9d9-7282-4f7c-976e-66f1b96e4aba)|![image](https://github.com/user-attachments/assets/c32c5928-6908-4f29-b4da-9250e811526a)|

To change the resampling quality setting for either downsampling or upsampling, simply change the values of the dictionary:

```py
from OSmOSE.core_api.audio_data import AudioData
from OSmOSE.core_api.spectro_data import SpectroData
from OSmOSE.config import resample_quality_settings as rqs

folder = Path(r"C:\Users\berthoga\Documents\Datasets\apocado_signal\data\audio\original")
afs = [AudioFile(f, strptime_format=r"%y%m%d%H%M%S") for f in folder.glob("*.wav")]

ad = AudioData(...)

ad.sample_rate /= 2 # example for downsampling

rqs["downsample"] = "VHQ" # Changing the downsampling quality to VHQ here

sd = SpectroData.from_audio_data(ad, sft)
sd.plot() # The resampling will be done according to the global OSmOSE.config.resample_quality_settings["downsample"] quality setting
plt.show()
```

## 🐳 Note

When these changes will be brought to the Public API (#256), I will have to send the quality settings to the job builder for the settings to be reapplied by each server when the API is used remotely.