### PR TITLE
Fix/gh actions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ permissions:
   id-token: write
 
 jobs:
-  build-linux:
+  build-documentation:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,7 +32,7 @@ jobs:
       run: uv sync --locked --all-extras --dev
 
     - name: Sphinx build
-      run: uv run sphinx-build docs _site
+      run: uv run sphinx-build docs/source _site
 
     - name: Upload Pages artifact
       uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/github_ci.yml
+++ b/.github/workflows/github_ci.yml
@@ -3,7 +3,7 @@ name: Test package
 on: [ push, pull_request ]
 
 jobs:
-  build-linux:
+  run-tests:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR:

- Explicits the names of the GH CI jobs so that they can be ran independently with act
- Fix the source folder of the documentation in the documentation.yml workflow