### PR TITLE
Fix/sd split instrument and normalization

### DIFF
--- a/src/osekit/core_api/audio_data.py
+++ b/src/osekit/core_api/audio_data.py
@@ -272,13 +272,18 @@ class AudioData(BaseData[AudioItem, AudioFile]):
             The list of AudioData subdata objects.
 
         """
+        normalization_values = (
+            self.normalization_values
+            if any(self.normalization_values.values())
+            else self.get_normalization_values()
+        )
         return [
             AudioData.from_base_data(
                 data=base_data,
                 sample_rate=self.sample_rate,
                 instrument=self.instrument,
                 normalization=self.normalization,
-                normalization_values=self.get_normalization_values(),
+                normalization_values=normalization_values,
             )
             for base_data in super().split(nb_subdata)
         ]
@@ -312,6 +317,11 @@ class AudioData(BaseData[AudioItem, AudioFile]):
             if stop_frame == -1
             else self.begin + Timedelta(seconds=stop_frame / self.sample_rate)
         )
+        normalization_values = (
+            self.normalization_values
+            if any(self.normalization_values.values())
+            else self.get_normalization_values()
+        )
         return AudioData.from_files(
             list(self.files),
             start_timestamp,
@@ -319,7 +329,7 @@ class AudioData(BaseData[AudioItem, AudioFile]):
             sample_rate=self.sample_rate,
             instrument=self.instrument,
             normalization=self.normalization,
-            normalization_values=self.get_normalization_values(),
+            normalization_values=normalization_values,
         )
 
     def to_dict(self) -> dict:

--- a/src/osekit/core_api/audio_data.py
+++ b/src/osekit/core_api/audio_data.py
@@ -94,6 +94,7 @@ class AudioData(BaseData[AudioItem, AudioFile]):
 
     @property
     def normalization_values(self) -> dict:
+        """Mean, peak and std values used for normalization."""
         return self._normalization_values
 
     @normalization_values.setter
@@ -316,6 +317,9 @@ class AudioData(BaseData[AudioItem, AudioFile]):
             start_timestamp,
             stop_timestamp,
             sample_rate=self.sample_rate,
+            instrument=self.instrument,
+            normalization=self.normalization,
+            normalization_values=self.get_normalization_values(),
         )
 
     def to_dict(self) -> dict:
@@ -381,6 +385,7 @@ class AudioData(BaseData[AudioItem, AudioFile]):
         sample_rate: float | None = None,
         instrument: Instrument | None = None,
         normalization: Normalization = Normalization.RAW,
+        normalization_values: dict | None = None,
     ) -> AudioData:
         """Return an AudioData object from a list of AudioFiles.
 
@@ -401,6 +406,8 @@ class AudioData(BaseData[AudioItem, AudioFile]):
             the wav audio data.
         normalization: Normalization
             The type of normalization to apply to the audio data.
+        normalization_values: dict|None
+            Mean, peak and std values with which to normalize the data.
 
         Returns
         -------
@@ -413,6 +420,7 @@ class AudioData(BaseData[AudioItem, AudioFile]):
             sample_rate=sample_rate,
             instrument=instrument,
             normalization=normalization,
+            normalization_values=normalization_values,
         )
 
     @classmethod

--- a/src/osekit/utils/audio_utils.py
+++ b/src/osekit/utils/audio_utils.py
@@ -120,19 +120,25 @@ def normalize_raw(values: np.ndarray) -> np.ndarray:
     return values
 
 
-def normalize_dc_reject(values: np.ndarray) -> np.ndarray:
+def normalize_dc_reject(
+    values: np.ndarray, dc_component: float | None = None
+) -> np.ndarray:
     """Reject the DC component of the audio data."""
-    return values - values.mean()
+    return values - (values.mean() if dc_component is None else dc_component)
 
 
-def normalize_peak(values: np.ndarray) -> np.ndarray:
+def normalize_peak(values: np.ndarray, peak: float | None = None) -> np.ndarray:
     """Return values normalized so that the peak value is 1.0."""
-    return values / max(abs(values))
+    return values / (max(abs(values)) if peak is None else peak)
 
 
-def normalize_zscore(values: np.ndarray) -> np.ndarray:
+def normalize_zscore(
+    values: np.ndarray, mean: float | None = None, std: float | None = None
+) -> np.ndarray:
     """Return normalized zscore from the audio data."""
-    return (values - values.mean()) / values.std()
+    mean = values.mean() if mean is None else mean
+    std = values.std() if std is None else std
+    return (values - mean) / std
 
 
 class NormalizationValider(enum.EnumMeta):
@@ -159,12 +165,18 @@ class Normalization(enum.Flag, metaclass=NormalizationValider):
     ZSCORE = enum.auto()
 
 
-def normalize(values: np.ndarray, normalization: Normalization) -> np.ndarray:
+def normalize(
+    values: np.ndarray,
+    normalization: Normalization,
+    mean: float | None = None,
+    peak: float | None = None,
+    std: float | None = None,
+) -> np.ndarray:
     """Normalize the audio data."""
     if Normalization.DC_REJECT in normalization:
-        values = normalize_dc_reject(values)
+        values = normalize_dc_reject(values=values, dc_component=mean)
     if Normalization.PEAK in normalization:
-        values = normalize_peak(values)
+        values = normalize_peak(values=values, peak=peak)
     if Normalization.ZSCORE in normalization:
-        values = normalize_zscore(values)
+        values = normalize_zscore(values=values, mean=mean, std=std)
     return values

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1566,6 +1566,21 @@ def test_split_data(
             assert subdata.instrument == data.instrument
             assert subdata.normalization == data.normalization
 
+            subsubdata_shape = subdata.shape // nb_subdata
+            for subsubdata, subdata_range in zip(
+                subdata.split(nb_subdata),
+                range(0, subdata.shape, subsubdata_shape),
+                strict=False,
+            ):
+                assert np.array_equal(
+                    subsubdata.get_value(),
+                    subdata.get_value()[
+                        subdata_range : subdata_range + subsubdata_shape
+                    ],
+                )
+                assert subsubdata.instrument == subdata.instrument
+                assert subsubdata.normalization == subdata.normalization
+
 
 @pytest.mark.parametrize(
     ("audio_files", "start_frame", "stop_frame", "expected_begin", "expected_data"),

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -22,6 +22,7 @@ from osekit.core_api.audio_data import AudioData
 from osekit.core_api.audio_dataset import AudioDataset
 from osekit.core_api.audio_file import AudioFile
 from osekit.core_api.audio_item import AudioItem
+from osekit.core_api.instrument import Instrument
 from osekit.utils import audio_utils
 from osekit.utils.audio_utils import generate_sample_audio, Normalization, normalize
 
@@ -1440,7 +1441,7 @@ def test_write_files(
 
 
 @pytest.mark.parametrize(
-    ("audio_files", "nb_subdata", "original_audio_data"),
+    ("audio_files", "nb_subdata", "instrument", "original_audio_data"),
     [
         pytest.param(
             {
@@ -1450,6 +1451,7 @@ def test_write_files(
                 "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
             },
             2,
+            None,
             generate_sample_audio(1, 48_000, dtype=np.float64),
             id="even_samples_split_in_two",
         ),
@@ -1461,6 +1463,7 @@ def test_write_files(
                 "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
             },
             4,
+            None,
             generate_sample_audio(1, 48_000, dtype=np.float64),
             id="even_samples_split_in_four",
         ),
@@ -1472,6 +1475,7 @@ def test_write_files(
                 "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
             },
             2,
+            None,
             generate_sample_audio(1, 48_000, dtype=np.float64),
             id="odd_samples_split_in_two",
         ),
@@ -1483,6 +1487,7 @@ def test_write_files(
                 "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
             },
             4,
+            None,
             generate_sample_audio(1, 48_001, dtype=np.float64),
             id="odd_samples_split_in_four",
         ),
@@ -1494,8 +1499,21 @@ def test_write_files(
                 "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
             },
             3,
+            None,
             generate_sample_audio(1, 10, dtype=np.float64),
             id="infinite_decimal_points",
+        ),
+        pytest.param(
+            {
+                "duration": 1,
+                "sample_rate": 48_000,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+            },
+            4,
+            Instrument(end_to_end_db=150.0),
+            generate_sample_audio(1, 48_000, dtype=np.float64),
+            id="audio_data_with_instrument",
         ),
     ],
     indirect=["audio_files"],
@@ -1504,11 +1522,13 @@ def test_split_data(
     tmp_path: Path,
     audio_files: tuple[list[Path], pytest.fixtures.Subrequest],
     nb_subdata: int,
+    instrument: Instrument | None,
     original_audio_data: list[np.ndarray],
 ) -> None:
     dataset = AudioDataset.from_folder(
         tmp_path,
         strptime_format=TIMESTAMP_FORMAT_EXPORTED_FILES_UNLOCALIZED,
+        instrument=instrument,
     )
     for data in dataset.data:
         subdata_shape = data.shape // nb_subdata
@@ -1521,6 +1541,7 @@ def test_split_data(
                 subdata.get_value(),
                 data.get_value()[data_range : data_range + subdata_shape],
             )
+            assert subdata.instrument == data.instrument
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
There was a bug where splitting an audio/spectro data would lose the audio data's instrument and normalization info.

It seemed like an easy-to-fix issue, but there's a tiny twist for the normalization part:

AudioDatas are normalized across their whole value (e.g. for a 5s-long audio data with a DC-REJECT normalization, the mean value accross the 5s of data will be substracted). If this AudioData is split in 2, the 2 distinct parts would be normalized according to their own mean.

Thus, I had to add a `AudioData.normalization_values` property which is a dict that might contains `mean`, `peak` and  `std` values used for normalizing the data.

When `AudioData.split()` is called, the resulting `AudioData` parts get instantiated with a `normalization_values` dictionary corresponding to the parent `AudioData`.