### PR TITLE
add Event __repr__ dunder

### DIFF
--- a/src/osekit/core_api/event.py
+++ b/src/osekit/core_api/event.py
@@ -24,7 +24,7 @@ class Event:
     def __init__(
         self,
         begin: Timestamp,
-        end: Timestamp
+        end: Timestamp,
     ) -> None:
         """Initialize an Event instance with a beginning and an end."""
         self.begin = begin
@@ -58,6 +58,9 @@ class Event:
     def duration(self) -> Timedelta:
         """Duration of the event."""
         return self.end - self.begin
+
+    def __repr__(self) -> str:
+        return str(self.begin)
 
     def overlaps(self, other: type[Event] | Event) -> bool:
         """Return True if the other event shares time with the current event.
@@ -149,7 +152,7 @@ class Event:
         """  # noqa: E501
         events = sorted(
             events,
-            key=lambda event: (event.begin, -1*event.duration),
+            key=lambda event: (event.begin, -1 * event.duration),
         )
         concatenated_events = []
         for event in events:


### PR DESCRIPTION
This is a tiny PR that simply overwrites the __repr__ method for the Event class, so that events appear as their begin timestamp:

<img width="378" height="280" alt="image" src="https://github.com/user-attachments/assets/06324cb0-2700-4f26-abec-2015d8c0c2d7" />
